### PR TITLE
feat: Remove BufReader req for GitOid construction

### DIFF
--- a/gitoid/src/ffi/gitoid.rs
+++ b/gitoid/src/ffi/gitoid.rs
@@ -140,11 +140,18 @@ pub extern "C" fn gitoid_new_from_reader(
     hash_algorithm: HashAlgorithm,
     object_type: ObjectType,
     fd: RawFd,
+    should_buffer: bool,
 ) -> GitOid {
     let output = catch_panic(|| {
         let file = unsafe { File::from_raw_fd(fd) };
-        let reader = BufReader::new(file);
-        let gitoid = GitOid::new_from_reader(hash_algorithm, object_type, reader)?;
+
+        let gitoid = if should_buffer {
+            let reader = BufReader::new(file);
+            GitOid::new_from_reader(hash_algorithm, object_type, reader)?
+        } else {
+            GitOid::new_from_reader(hash_algorithm, object_type, file)?
+        };
+
         Ok(gitoid)
     });
 

--- a/gitoid/src/gitoid.rs
+++ b/gitoid/src/gitoid.rs
@@ -97,7 +97,7 @@ impl GitOid {
     pub fn new_from_reader<R>(
         hash_algorithm: HashAlgorithm,
         object_type: ObjectType,
-        mut reader: BufReader<R>,
+        mut reader: R,
     ) -> Result<Self>
     where
         R: Read + Seek,
@@ -220,12 +220,12 @@ impl TryFrom<Url> for GitOid {
 /// wrong and the hash is not valid.
 fn bytes_from_buffer<R>(
     mut digester: Box<dyn DynDigest>,
-    mut reader: BufReader<R>,
+    mut reader: R,
     expected_length: usize,
     object_type: ObjectType,
 ) -> Result<(usize, [u8; NUM_HASH_BYTES])>
 where
-    BufReader<R>: Read,
+    R: Read,
 {
     let prefix = format!("{} {}\0", object_type, expected_length);
 


### PR DESCRIPTION
Previously we required buffering when constructing a GitOid
from a file, but this isn't always desirable. This commit makes
the API generic over any reader, and also updates the FFI to
make buffering optional.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>

Closes #79 