### PR TITLE
Shortened GitOid constructor names.

### DIFF
--- a/gitoid/src/ffi/gitoid.rs
+++ b/gitoid/src/ffi/gitoid.rs
@@ -127,7 +127,7 @@ macro_rules! generate_gitoid_ffi_for_hash {
                 let output = catch_panic(|| {
                     check_null(content, Error::ContentPtrIsNull)?;
                     let content = unsafe { from_raw_parts(content, content_len) };
-                    let gitoid = GitOid::<$hash_ty, $object_ty>::new_from_bytes(content);
+                    let gitoid = GitOid::<$hash_ty, $object_ty>::from_bytes(content);
                     let boxed = Box::new(gitoid);
                     Ok(Box::into_raw(boxed) as *const _)
                 });
@@ -149,7 +149,7 @@ macro_rules! generate_gitoid_ffi_for_hash {
                 let output = catch_panic(|| {
                     check_null(s, Error::StringPtrIsNull)?;
                     let s = unsafe { CStr::from_ptr(s) }.to_str()?;
-                    let gitoid = GitOid::<$hash_ty, $object_ty>::new_from_str(s);
+                    let gitoid = GitOid::<$hash_ty, $object_ty>::from_str(s);
                     let boxed = Box::new(gitoid);
                     Ok(Box::into_raw(boxed) as *const _)
                 });
@@ -172,7 +172,7 @@ macro_rules! generate_gitoid_ffi_for_hash {
                     check_null(s, Error::StringPtrIsNull)?;
                     let raw_url = unsafe { CStr::from_ptr(s) }.to_str()?;
                     let url = Url::parse(raw_url)?;
-                    let gitoid = GitOid::<$hash_ty, $object_ty>::new_from_url(url)?;
+                    let gitoid = GitOid::<$hash_ty, $object_ty>::from_url(url)?;
                     let boxed = Box::new(gitoid);
                     Ok(Box::into_raw(boxed) as *const _)
                 });
@@ -198,9 +198,9 @@ macro_rules! generate_gitoid_ffi_for_hash {
 
                     let gitoid = if should_buffer {
                         let reader = BufReader::new(file);
-                        GitOid::<$hash_ty, $object_ty>::new_from_reader(reader)?
+                        GitOid::<$hash_ty, $object_ty>::from_reader(reader)?
                     } else {
-                        GitOid::<$hash_ty, $object_ty>::new_from_reader(file)?
+                        GitOid::<$hash_ty, $object_ty>::from_reader(file)?
                     };
 
                     let boxed = Box::new(gitoid);

--- a/gitoid/src/tests.rs
+++ b/gitoid/src/tests.rs
@@ -8,7 +8,7 @@ use url::Url;
 #[test]
 fn generate_sha1_gitoid_from_bytes() {
     let input = b"hello world";
-    let result = GitOid::<Sha1, Blob>::new_from_bytes(input);
+    let result = GitOid::<Sha1, Blob>::from_bytes(input);
 
     assert_eq!(result.as_hex(), "95d09f2b10159347eece71399a7e2e907ea3df4f");
 
@@ -21,7 +21,7 @@ fn generate_sha1_gitoid_from_bytes() {
 #[test]
 fn generate_sha1_gitoid_from_buffer() -> Result<()> {
     let reader = BufReader::new(File::open("test/data/hello_world.txt")?);
-    let result = GitOid::<Sha1, Blob>::new_from_reader(reader)?;
+    let result = GitOid::<Sha1, Blob>::from_reader(reader)?;
 
     assert_eq!(result.as_hex(), "95d09f2b10159347eece71399a7e2e907ea3df4f");
 
@@ -36,7 +36,7 @@ fn generate_sha1_gitoid_from_buffer() -> Result<()> {
 #[test]
 fn generate_sha256_gitoid_from_bytes() {
     let input = b"hello world";
-    let result = GitOid::<Sha256, Blob>::new_from_bytes(input);
+    let result = GitOid::<Sha256, Blob>::from_bytes(input);
 
     assert_eq!(
         result.as_hex(),
@@ -52,7 +52,7 @@ fn generate_sha256_gitoid_from_bytes() {
 #[test]
 fn generate_sha256_gitoid_from_buffer() -> Result<()> {
     let reader = BufReader::new(File::open("test/data/hello_world.txt")?);
-    let result = GitOid::<Sha256, Blob>::new_from_reader(reader)?;
+    let result = GitOid::<Sha256, Blob>::from_reader(reader)?;
 
     assert_eq!(
         result.as_hex(),
@@ -70,7 +70,7 @@ fn generate_sha256_gitoid_from_buffer() -> Result<()> {
 #[test]
 fn validate_uri() -> Result<()> {
     let content = b"hello world";
-    let gitoid = GitOid::<Sha256, Blob>::new_from_bytes(content);
+    let gitoid = GitOid::<Sha256, Blob>::from_bytes(content);
 
     assert_eq!(
         gitoid.url().to_string(),
@@ -87,7 +87,7 @@ fn try_from_url_bad_scheme() {
     )
     .unwrap();
 
-    match GitOid::<Sha256, Blob>::new_from_url(url) {
+    match GitOid::<Sha256, Blob>::from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
         Err(e) => assert_eq!(e.to_string(), "invalid scheme in URL 'whatever'"),
     }
@@ -97,7 +97,7 @@ fn try_from_url_bad_scheme() {
 fn try_from_url_missing_object_type() {
     let url = Url::parse("gitoid:").unwrap();
 
-    match GitOid::<Sha1, Blob>::new_from_url(url) {
+    match GitOid::<Sha1, Blob>::from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
         Err(e) => assert_eq!(e.to_string(), "missing object type in URL 'gitoid:'"),
     }
@@ -107,7 +107,7 @@ fn try_from_url_missing_object_type() {
 fn try_from_url_bad_object_type() {
     let url = Url::parse("gitoid:whatever").unwrap();
 
-    match GitOid::<Sha1, Blob>::new_from_url(url) {
+    match GitOid::<Sha1, Blob>::from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
         Err(e) => assert_eq!(
             e.to_string(),
@@ -120,7 +120,7 @@ fn try_from_url_bad_object_type() {
 fn try_from_url_missing_hash_algorithm() {
     let url = Url::parse("gitoid:blob:").unwrap();
 
-    match GitOid::<Sha256, Blob>::new_from_url(url) {
+    match GitOid::<Sha256, Blob>::from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
         Err(e) => assert_eq!(
             e.to_string(),
@@ -133,7 +133,7 @@ fn try_from_url_missing_hash_algorithm() {
 fn try_from_url_bad_hash_algorithm() {
     let url = Url::parse("gitoid:blob:sha10000").unwrap();
 
-    match GitOid::<Sha1, Blob>::new_from_url(url) {
+    match GitOid::<Sha1, Blob>::from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
         Err(e) => assert_eq!(
             e.to_string(),
@@ -146,7 +146,7 @@ fn try_from_url_bad_hash_algorithm() {
 fn try_from_url_missing_hash() {
     let url = Url::parse("gitoid:blob:sha256:").unwrap();
 
-    match GitOid::<Sha256, Blob>::new_from_url(url) {
+    match GitOid::<Sha256, Blob>::from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
         Err(e) => assert_eq!(e.to_string(), "missing hash in URL 'gitoid:blob:sha256:'"),
     }
@@ -158,7 +158,7 @@ fn try_url_roundtrip() {
         "gitoid:blob:sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03",
     )
     .unwrap();
-    let gitoid = GitOid::<Sha256, Blob>::new_from_url(url.clone()).unwrap();
+    let gitoid = GitOid::<Sha256, Blob>::from_url(url.clone()).unwrap();
     let output = gitoid.url();
 
     eprintln!("{}", url);


### PR DESCRIPTION
This commit shortens constructor names to make code a little easier to parse visually.