### PR TITLE
feat: rewrite docs intro, reorg docs slightly

### DIFF
--- a/gitoid/src/ffi/mod.rs
+++ b/gitoid/src/ffi/mod.rs
@@ -1,6 +1,9 @@
 //! `gitoid` Foreign Function Interface (FFI)
 
-pub mod error;
-pub mod gitoid;
-pub mod status;
-pub mod util;
+pub(crate) mod error;
+mod gitoid;
+pub(crate) mod status;
+pub(crate) mod util;
+
+// Re-export
+pub use crate::ffi::gitoid::*;

--- a/gitoid/src/gitoid.rs
+++ b/gitoid/src/gitoid.rs
@@ -21,7 +21,8 @@ use std::io::Seek;
 use std::io::SeekFrom;
 use std::str::FromStr;
 use std::str::Split;
-use std::{hash::Hasher, io::BufReader};
+use std::hash::Hasher;
+use std::io::BufReader;
 use url::Url;
 
 /// A struct that computes [gitoids][g] based on the selected algorithm
@@ -98,10 +99,9 @@ where
     }
 
     /// Create a `GitOid` from a reader.
-    pub fn from_reader<R>(mut reader: R) -> Result<GitOid<H, O>>
-    where
-        R: Read + Seek,
-    {
+    pub fn from_reader<R: Read + Seek>(
+        mut reader: R
+    ) -> Result<GitOid<H, O>> {
         let digester = H::new();
         let expected_length = stream_len(&mut reader)? as usize;
         gitoid_from_buffer(digester, reader, expected_length)

--- a/gitoid/src/lib.rs
+++ b/gitoid/src/lib.rs
@@ -1,14 +1,21 @@
 //! A content-addressable identity for software artifacts.
 //!
-//! GitOIDs are a mechanism for identifying artifacts in a manner which is
-//! independently reproducible because it relies solely on the contents of
-//! the artifact itself.
+//! ## What are GitOIDs?
+//! 
+//! Git Object Identifiers ([GitOIDs][gitoid]) are a mechanism for
+//! identifying artifacts in a manner which is independently reproducible
+//! because it relies only on the contents of the artifact itself.
 //!
 //! The GitOID scheme comes from the Git version control system, which uses
 //! this mechanism to identify commits, tags, files (called "blobs"), and
-//! directories (called "trees"). It's also used by the GitBOM standard for
-//! identifying inputs which produce software artifacts.
+//! directories (called "trees").
+//! 
+//! This implementation of GitOIDs is produced by the [OmniBOR][omnibor]
+//! working group, which uses GitOIDs as the basis for OmniBOR Artifact
+//! Identifiers.
 //!
+//! ### GitOID URL Scheme
+//! 
 //! `gitoid` is also an IANA-registered URL scheme, meaning that GitOIDs
 //! are represented and shared as URLs. A `gitoid` URL looks like:
 //!
@@ -16,11 +23,20 @@
 //! gitoid:blob:sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03
 //! ```
 //!
-//! This scheme starts with "`gitoid`", followed by the object type ("`blob`"
-//! in this case), the hash algorithm ("`sha256`"), and the hash of the
-//! artifact the GitOID represents. Each of these parts is separated
-//! by a colon.
+//! This scheme starts with "`gitoid`", followed by the object type
+//! ("`blob`" in this case), the hash algorithm ("`sha256`"), and the
+//! hash produced by the GitOID hash construction. Each of these parts is
+//! separated by a colon.
 //!
+//! ### GitOID Hash Construction
+//! 
+//! GitOID hashes are made by hashing a prefix string containing the object
+//! type and the size of the object being hashed in bytes, followed by a null
+//! terminator, and then hashing the object itself. So GitOID hashes do not
+//! match the result of only hashing the object.
+//! 
+//! ### GitOID Object Types
+//! 
 //! The valid object types for a GitOID are:
 //!
 //! - `blob`
@@ -28,17 +44,58 @@
 //! - `commit`
 //! - `tag`
 //!
+//! Currently, this crate implements convenient handling of `blob` objects,
+//! but does not handle ensuring the proper formatting of `tree`, `commit`,
+//! or `tag` objects to match the Git implementation.
+//! 
+//! ### GitOID Hash Algorithms
+//! 
 //! The valid hash algorithms are:
 //!
 //! - `sha1`
+//! - `sha1dc`
 //! - `sha256`
 //!
+//! `sha1dc` is actually Git's default algorithm, and is equivalent to `sha1`
+//! in _most_ cases. Where it differs is when the hasher detects what it
+//! believes to be an attempt to generate a purposeful SHA-1 collision,
+//! in which case it modifies the hash process to produce a different output
+//! and avoid the malicious collision.
+//! 
+//! Git does this under the hood, but does not clearly distinguish to end
+//! users that the underlying hashing algorithm isn't equivalent to SHA-1.
+//! This is fine for Git, where the specific hash used is an implementation
+//! detail and only matters within a single repository, but for the OmniBOR
+//! working group it's important to distinguish whether plain SHA-1 or
+//! SHA-1DC is being used, so it's distinguished in the code for this crate.
+//! 
+//! This means for compatibility with Git that SHA-1DC should be used.
+//! 
+//! ## Why Care About GitOIDs?
+//! 
 //! GitOIDs provide a convenient mechanism to establish artifact identity and
 //! validate artifact integrity (this artifact hasn't been modified) and
-//! agreement (I have the same artifact you have).
+//! agreement (I have the same artifact you have). The fact that they're based
+//! only on the type of object ("`blob`", usually) and the artifact itself
+//! means they can be derived independently, enabling distributed artifact
+//! identification that avoids a central decider.
+//! 
+//! Alternative identity schemes, like Package URLs (purls) or Common Platform
+//! Enumerations (CPEs) rely on central authorities to produce identifiers or
+//! define the taxonomy in which identifiers are produced.
+//! 
+//! ## Using this Crate
+//! 
+//! The central type of this crate is [`GitOid`], which is generic over both
+//! the hash algorithm used and the object type being identified. The
+//! [`HashAlgorithm`] trait, which is sealed, is implemented by the types
+//! found in `gitoid::hash`. The [`ObjectType`] trait, which is also sealed,
+//! is implemented by the types found in `gitoid::object`.
+//! 
+//! [gitoid]: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
+//! [omnibor]: https://omnibor.io
 
 mod error;
-#[doc(hidden)]
 pub mod ffi;
 mod gitoid;
 mod hash_algorithm;
@@ -59,7 +116,10 @@ pub mod object {
     #[cfg(doc)]
     use crate::GitOid;
 
-    pub use crate::object_type::{Blob, Commit, Tag, Tree};
+    pub use crate::object_type::Blob;
+    pub use crate::object_type::Commit;
+    pub use crate::object_type::Tag;
+    pub use crate::object_type::Tree;
 }
 
 pub mod hash {
@@ -68,9 +128,12 @@ pub mod hash {
     #[cfg(doc)]
     use crate::GitOid;
 
-    pub use sha1::Sha1;
-    pub use sha2::Sha256;
+    /// SHA-1 hasher.
+    pub type Sha1 = sha1::Sha1;
 
-    /// Sha-1CD hasher.
+    /// SHA-1CD hasher.
     pub type Sha1Cd = sha1collisiondetection::Sha1CD;
+
+    /// SHA-256 hasher.
+    pub type Sha256 = sha2::Sha256;
 }


### PR DESCRIPTION
This commit rewrites the introductory docs for the crate,
and also reorganizes some docs for FFI and hashes slightly
to be clearer / cleaner. FFI is no longer marked doc(hidden),
and the contents of crate::ffi::gitoid have been re-exported
to appear under crate::ffi directly. This isn't _really_ that
important since they're only intended to be called from C
code anyway, but at least this way they appear in the Rust
docs and are easier to find.