### PR TITLE
feat: improved gitoid_from_buffer, misc. fixups

### DIFF
--- a/gitoid/Cargo.toml
+++ b/gitoid/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["rlib", "cdylib"]
 [dependencies]
 # Match the version used in sha1 and sha2.
 digest = "0.10.7"
+format-bytes = "0.3.0"
 # Match the version used in sha1, sha2, and digest.
 generic-array = "0.14.7"
 hex = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/gitoid/src/hash_algorithm.rs
+++ b/gitoid/src/hash_algorithm.rs
@@ -8,10 +8,6 @@ use sha1::Sha1;
 use sha1collisiondetection::Sha1CD as Sha1Cd;
 use sha2::Sha256;
 
-mod private {
-    pub trait Sealed {}
-}
-
 /// Hash algorithms that can be used to make a [`GitOid`].
 ///
 /// This is a sealed trait to ensure it's only used for hash

--- a/gitoid/src/lib.rs
+++ b/gitoid/src/lib.rs
@@ -1,7 +1,7 @@
 //! A content-addressable identity for software artifacts.
 //!
 //! ## What are GitOIDs?
-//! 
+//!
 //! Git Object Identifiers ([GitOIDs][gitoid]) are a mechanism for
 //! identifying artifacts in a manner which is independently reproducible
 //! because it relies only on the contents of the artifact itself.
@@ -9,13 +9,13 @@
 //! The GitOID scheme comes from the Git version control system, which uses
 //! this mechanism to identify commits, tags, files (called "blobs"), and
 //! directories (called "trees").
-//! 
+//!
 //! This implementation of GitOIDs is produced by the [OmniBOR][omnibor]
 //! working group, which uses GitOIDs as the basis for OmniBOR Artifact
 //! Identifiers.
 //!
 //! ### GitOID URL Scheme
-//! 
+//!
 //! `gitoid` is also an IANA-registered URL scheme, meaning that GitOIDs
 //! are represented and shared as URLs. A `gitoid` URL looks like:
 //!
@@ -29,14 +29,14 @@
 //! separated by a colon.
 //!
 //! ### GitOID Hash Construction
-//! 
+//!
 //! GitOID hashes are made by hashing a prefix string containing the object
 //! type and the size of the object being hashed in bytes, followed by a null
 //! terminator, and then hashing the object itself. So GitOID hashes do not
 //! match the result of only hashing the object.
-//! 
+//!
 //! ### GitOID Object Types
-//! 
+//!
 //! The valid object types for a GitOID are:
 //!
 //! - `blob`
@@ -47,9 +47,9 @@
 //! Currently, this crate implements convenient handling of `blob` objects,
 //! but does not handle ensuring the proper formatting of `tree`, `commit`,
 //! or `tag` objects to match the Git implementation.
-//! 
+//!
 //! ### GitOID Hash Algorithms
-//! 
+//!
 //! The valid hash algorithms are:
 //!
 //! - `sha1`
@@ -61,37 +61,37 @@
 //! believes to be an attempt to generate a purposeful SHA-1 collision,
 //! in which case it modifies the hash process to produce a different output
 //! and avoid the malicious collision.
-//! 
+//!
 //! Git does this under the hood, but does not clearly distinguish to end
 //! users that the underlying hashing algorithm isn't equivalent to SHA-1.
 //! This is fine for Git, where the specific hash used is an implementation
 //! detail and only matters within a single repository, but for the OmniBOR
 //! working group it's important to distinguish whether plain SHA-1 or
 //! SHA-1DC is being used, so it's distinguished in the code for this crate.
-//! 
+//!
 //! This means for compatibility with Git that SHA-1DC should be used.
-//! 
+//!
 //! ## Why Care About GitOIDs?
-//! 
+//!
 //! GitOIDs provide a convenient mechanism to establish artifact identity and
 //! validate artifact integrity (this artifact hasn't been modified) and
 //! agreement (I have the same artifact you have). The fact that they're based
 //! only on the type of object ("`blob`", usually) and the artifact itself
 //! means they can be derived independently, enabling distributed artifact
 //! identification that avoids a central decider.
-//! 
+//!
 //! Alternative identity schemes, like Package URLs (purls) or Common Platform
 //! Enumerations (CPEs) rely on central authorities to produce identifiers or
 //! define the taxonomy in which identifiers are produced.
-//! 
+//!
 //! ## Using this Crate
-//! 
+//!
 //! The central type of this crate is [`GitOid`], which is generic over both
 //! the hash algorithm used and the object type being identified. The
 //! [`HashAlgorithm`] trait, which is sealed, is implemented by the types
 //! found in `gitoid::hash`. The [`ObjectType`] trait, which is also sealed,
 //! is implemented by the types found in `gitoid::object`.
-//! 
+//!
 //! [gitoid]: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
 //! [omnibor]: https://omnibor.io
 

--- a/gitoid/test/c/test.c
+++ b/gitoid/test/c/test.c
@@ -7,22 +7,22 @@
 #define LEN(arr) (sizeof(arr) / sizeof(arr[0]));
 #define TEST(NAME) {.name = #NAME, .fn = NAME}
 
-void test_gitoid_new_from_str() {
-    const GitOidSha1Blob* gitoid = gitoid_sha1_blob_new_from_str("hello world");
+void test_gitoid_from_str() {
+    const GitOidSha1Blob* gitoid = gitoid_sha1_blob_from_str("hello world");
     assert(gitoid != NULL);
     assert(gitoid_sha1_blob_hash_len() == 20);
     assert(gitoid_sha1_blob_get_hash_bytes(gitoid)[0] == 149);
     gitoid_sha1_blob_free(gitoid);
 }
 
-void test_gitoid_new_from_bytes() {
+void test_gitoid_from_bytes() {
     unsigned char bytes[] = {0x00, 0x01, 0x02, 0x03,
                              0x04, 0x05, 0x06, 0x07,
                              0x08, 0x09, 0x0A, 0x0B,
                              0x0C, 0x0D, 0x0E, 0x0F};
     uint8_t bytes_len = LEN(bytes);
 
-    const GitOidSha1Blob* gitoid = gitoid_sha1_blob_new_from_bytes(
+    const GitOidSha1Blob* gitoid = gitoid_sha1_blob_from_bytes(
         bytes,
         bytes_len
     );
@@ -33,9 +33,9 @@ void test_gitoid_new_from_bytes() {
     gitoid_sha1_blob_free(gitoid);
 }
 
-void test_gitoid_new_from_url() {
+void test_gitoid_from_url() {
     char *url = "gitoid:blob:sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03";
-    const GitOidSha256Blob* gitoid = gitoid_sha256_blob_new_from_url(url);
+    const GitOidSha256Blob* gitoid = gitoid_sha256_blob_from_url(url);
     assert(gitoid != NULL);
     assert(gitoid_sha256_blob_hash_len() == 32);
     assert(gitoid_sha256_blob_get_hash_bytes(gitoid)[0] == 254);
@@ -44,7 +44,7 @@ void test_gitoid_new_from_url() {
 
 void test_gitoid_get_url() {
     char *url_in = "gitoid:blob:sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03";
-    const GitOidSha256Blob* gitoid = gitoid_sha256_blob_new_from_url(url_in);
+    const GitOidSha256Blob* gitoid = gitoid_sha256_blob_from_url(url_in);
     assert(gitoid != NULL);
     const char *url_out = gitoid_sha256_blob_get_url(gitoid);
     assert(strncmp(url_in, url_out, 83) == 0);
@@ -53,7 +53,7 @@ void test_gitoid_get_url() {
 }
 
 void test_gitoid_hash_algorithm_name() {
-    const GitOidSha1Blob* gitoid = gitoid_sha1_blob_new_from_str("hello world");
+    const GitOidSha1Blob* gitoid = gitoid_sha1_blob_from_str("hello world");
     assert(gitoid != NULL);
     const char *hash_algorithm = gitoid_sha1_blob_hash_algorithm_name(gitoid);
     assert(strncmp(hash_algorithm, "sha1", 4) == 0);
@@ -61,7 +61,7 @@ void test_gitoid_hash_algorithm_name() {
 }
 
 void test_gitoid_object_type_name() {
-    const GitOidSha1Blob* gitoid = gitoid_sha1_blob_new_from_str("hello world");
+    const GitOidSha1Blob* gitoid = gitoid_sha1_blob_from_str("hello world");
     assert(gitoid != NULL);
     const char *object_type = gitoid_sha1_blob_object_type_name(gitoid);
     assert(strncmp(object_type, "blob", 4) == 0);
@@ -70,7 +70,7 @@ void test_gitoid_object_type_name() {
 
 void test_gitoid_validity() {
     char *validity_url = "gitoid:blob:sha000:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03";
-    const GitOidSha1Blob* gitoid = gitoid_sha1_blob_new_from_url(validity_url);
+    const GitOidSha1Blob* gitoid = gitoid_sha1_blob_from_url(validity_url);
     assert(gitoid == NULL);
 
     char *expected_msg = "string is not a valid GitOID URL";
@@ -90,9 +90,9 @@ int main() {
     setvbuf(stdout, NULL, _IONBF, 0);
 
     test_t tests[] = {
-        TEST(test_gitoid_new_from_str),
-        TEST(test_gitoid_new_from_bytes),
-        TEST(test_gitoid_new_from_url),
+        TEST(test_gitoid_from_str),
+        TEST(test_gitoid_from_bytes),
+        TEST(test_gitoid_from_url),
         TEST(test_gitoid_get_url),
         TEST(test_gitoid_hash_algorithm_name),
         TEST(test_gitoid_object_type_name),


### PR DESCRIPTION
This commit does a few things:

- Refactors gitoid_from_buffer to delegate to BufReader.
- Uses format_bytes::format_bytes instead of format to construct
  prefix for hashing.
- Adds GitOid::from_reader_with_expected_length to support
  non-Seek-able readers and avoid cost of seeking if length is
  already known.
- Adds GITOID_URL_SCHEME constant to replace two uses of
  literal string and ensure they're always consistent.
- Updates FFI to support new from_reader_with_expected_length
- Updates FFI to avoid double-buffering when building a GitOid
  from a reader, since the underlying implementation buffers.
- Adds FFI support for new from_reader_with_expected_length
  constructor.
- Renames FFI constructor from _new_from_* to _from_*, and
  updates C test code to use the new prefix.