### PR TITLE
fix: Fixed broken FFI code on Windows.

### DIFF
--- a/gitoid/src/ffi/gitoid.rs
+++ b/gitoid/src/ffi/gitoid.rs
@@ -241,7 +241,7 @@ macro_rules! generate_gitoid_ffi_for_hash {
                 let output = catch_panic(|| {
                     let file = unsafe { File::from_raw_handle(handle) };
                     let reader = BufReader::new(file);
-                    let gitoid = GitOid::<$hash_ty, $object_ty>::new_from_reader(reader)?;
+                    let gitoid = GitOid::<$hash_ty, $object_ty>::from_reader(reader)?;
                     let boxed = Box::new(gitoid);
                     Ok(Box::into_raw(boxed) as *const _)
                 });
@@ -267,7 +267,7 @@ macro_rules! generate_gitoid_ffi_for_hash {
                     let file = unsafe { File::from_raw_handle(handle) };
                     let expected_length = expected_length as usize;
                     let reader = BufReader::new(file);
-                    let gitoid = GitOid::<$hash_ty, $object_ty>::new_from_reader_with_expected_length(reader, expected_length)?;
+                    let gitoid = GitOid::<$hash_ty, $object_ty>::from_reader_with_expected_length(reader, expected_length)?;
                     let boxed = Box::new(gitoid);
                     Ok(Box::into_raw(boxed) as *const _)
                 });


### PR DESCRIPTION
Haha this is why we need Windows CI jobs. A prior
commit missed updating two function calls in the
Windows FFI code, causing compilation issues. This
commit fixes it.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>