### PR TITLE
feat: Add async constructors for GitOid.

### DIFF
--- a/gitoid/Cargo.toml
+++ b/gitoid/Cargo.toml
@@ -24,4 +24,5 @@ paste = "1.0.14"
 sha1 = { version = "0.10.6", default-features = false, features = ["std"] }
 sha1collisiondetection = "0.3.3"
 sha2 = { version = "0.10.8", default-features = false }
+tokio = { version = "1.36.0", features = ["io-util"] }
 url = "2.4.1"


### PR DESCRIPTION
This commits adds two new constructors for `GitOid` to build new
GitOIDs from async readers, with or without an expected length
being provided.

This was pretty easy! I've generally stayed away from doing async
things because of the general vibe that it's kinda finicky / difficult.
I'm happy this was so simple to do.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
