### PR TITLE
feat: add top-level docs example.

### DIFF
--- a/gitoid/src/lib.rs
+++ b/gitoid/src/lib.rs
@@ -90,6 +90,18 @@
 //! the hash algorithm used and the object type being identified. These are
 //! defined by the [`HashAlgorithm`] and [`ObjectType`] traits.
 //!
+//! ## Example
+//!
+//! ```rust
+//! # use gitoid::{Sha256, Blob};
+//!
+//! type GitOid = gitoid::GitOid<Sha256, Blob>;
+//!
+//! let gitoid: GitOid = gitoid::GitOid::from_str("hello, world");
+//!
+//! println!("gitoid: {}", gitoid);
+//! ```
+//!
 //! [gitoid]: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
 //! [omnibor]: https://omnibor.io
 

--- a/gitoid/src/object_type.rs
+++ b/gitoid/src/object_type.rs
@@ -11,6 +11,8 @@ use crate::GitOid;
 ///
 /// For more information on sealed traits, read Predrag
 /// Gruevski's ["A Definitive Guide to Sealed Traits in Rust"][1].
+///
+/// [1]: https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/
 pub trait ObjectType: Sealed {
     #[doc(hidden)]
     const NAME: &'static str;


### PR DESCRIPTION
This commit adds a top-level example to the crate docs, and also fixes
a broken link in the docs for ObjectType.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
