### PR TITLE
feat: make GitOid display print URL format

### DIFF
--- a/gitoid/src/gitoid.rs
+++ b/gitoid/src/gitoid.rs
@@ -120,15 +120,9 @@ where
 
     /// Get a URL for the current `GitOid`.
     pub fn url(&self) -> Url {
-        // PANIC SAFETY: We know that this is a valid URL.
-        Url::parse(&format!(
-            "{}:{}:{}:{}",
-            GITOID_URL_SCHEME,
-            O::NAME,
-            H::NAME,
-            self.as_hex()
-        ))
-        .unwrap()
+        // PANIC SAFETY: We know that this is a valid URL;
+        //               our `Display` impl is the URL representation.
+        Url::parse(&self.to_string()).unwrap()
     }
 
     /// Get the underlying bytes of the hash.
@@ -254,7 +248,14 @@ where
     O: ObjectType,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{}:{}", H::NAME, self.as_hex())
+        write!(
+            f,
+            "{}:{}:{}:{}",
+            GITOID_URL_SCHEME,
+            O::NAME,
+            H::NAME,
+            self.as_hex()
+        )
     }
 }
 

--- a/gitoid/src/tests.rs
+++ b/gitoid/src/tests.rs
@@ -13,7 +13,7 @@ fn generate_sha1_gitoid_from_bytes() {
 
     assert_eq!(
         result.to_string(),
-        "sha1:95d09f2b10159347eece71399a7e2e907ea3df4f"
+        "gitoid:blob:sha1:95d09f2b10159347eece71399a7e2e907ea3df4f"
     );
 }
 
@@ -26,7 +26,7 @@ fn generate_sha1_gitoid_from_buffer() -> Result<()> {
 
     assert_eq!(
         result.to_string(),
-        "sha1:95d09f2b10159347eece71399a7e2e907ea3df4f"
+        "gitoid:blob:sha1:95d09f2b10159347eece71399a7e2e907ea3df4f"
     );
 
     Ok(())
@@ -44,7 +44,7 @@ fn generate_sha256_gitoid_from_bytes() {
 
     assert_eq!(
         result.to_string(),
-        "sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
+        "gitoid:blob:sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
     );
 }
 
@@ -60,7 +60,7 @@ fn generate_sha256_gitoid_from_buffer() -> Result<()> {
 
     assert_eq!(
         result.to_string(),
-        "sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
+        "gitoid:blob:sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
     );
 
     Ok(())
@@ -80,7 +80,7 @@ fn generate_sha256_gitoid_from_async_buffer() -> Result<()> {
 
         assert_eq!(
             result.to_string(),
-            "sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
+            "gitoid:blob:sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
         );
 
         Ok(())


### PR DESCRIPTION
Previously the Display impl for GitOid printed some but not all of the
data associated with the URL representation. This commit changes that to
just print the URL representation, and updates the GitOid::url method
to delegate to `to_string` which delegates to that `Display` impl.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>