### PR TITLE
feat: introduce new OmniBOR CLI.

### DIFF
--- a/omnibor/Cargo.toml
+++ b/omnibor/Cargo.toml
@@ -14,7 +14,18 @@ version = "0.3.0"
 gitoid = "0.5.0"
 tokio = { version = "1.36.0", features = ["io-util"] }
 url = "2.5.0"
+clap = { version = "4.5.1", features = ["derive"], optional = true }
+anyhow = { version = "1.0.80", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["io-util", "fs"] }
 tokio-test = "0.4.3"
+
+[features]
+build-binary = ["anyhow", "clap"]
+
+[[bin]]
+name = "omnibor"
+test = false
+bench = false
+required-features = ["build-binary"]

--- a/omnibor/src/bin/omnibor.rs
+++ b/omnibor/src/bin/omnibor.rs
@@ -1,0 +1,67 @@
+use anyhow::Context as _;
+use anyhow::Result;
+use clap::Args;
+use clap::Parser;
+use clap::Subcommand;
+use omnibor::Sha256;
+use std::fs::File;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args = Cli::parse();
+
+    let result = match args.command {
+        Command::Id(args) => run_id(args),
+    };
+
+    if let Err(err) = result {
+        eprintln!("{}", err);
+        return ExitCode::FAILURE;
+    }
+
+    ExitCode::SUCCESS
+}
+
+
+/*===========================================================================
+ * CLI Arguments
+ *-------------------------------------------------------------------------*/
+
+#[derive(Debug, Parser)]
+#[command(version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Print the Artifact ID of the path given.
+    Id(IdArgs),
+}
+
+#[derive(Debug, Args)]
+struct IdArgs {
+    /// The path to identify.
+    path: PathBuf,
+}
+
+
+/*===========================================================================
+ * Command Implementations
+ *-------------------------------------------------------------------------*/
+
+/// Type alias for the specific ID we're using.
+type ArtifactId = omnibor::ArtifactId<Sha256>;
+
+/// Run the `id` subcommand.
+///
+/// This command just produces the `gitoid` URL for the given file.
+fn run_id(args: IdArgs) -> Result<()> {
+    let path = &args.path;
+    let file = File::open(path).with_context(|| format!("failed to open '{}'", path.display()))?;
+    let id = ArtifactId::id_reader(&file).context("failed to produce Artifact ID")?;
+    println!("{}", id.url());
+    Ok(())
+}


### PR DESCRIPTION
This commit introduces a new, and currently very basic, OmniBOR CLI.

At the moment, this CLI is only able to produce Artifact Identifiers
for files it's given. In the future it'll be expanded with more
functionality.

To use the CLI during development, run:

    cargo run --features="build-binary" -- <CLI ARGS>

Replace `<CLI ARGS>` with arguments for the CLI. Use the `--help` flag
to find out the API of the CLI.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
