### PR TITLE
fix: Fix double-print in tree command.

### DIFF
--- a/omnibor/Cargo.toml
+++ b/omnibor/Cargo.toml
@@ -21,7 +21,6 @@ url = "2.5.0"
 # Binary-only dependencies
 
 anyhow = { version = "1.0.80", optional = true }
-async-recursion = { version = "1.0.5", optional = true }
 async-walkdir = { version = "1.0.0", optional = true }
 clap = { version = "4.5.1", features = ["derive"], optional = true }
 futures-lite = { version = "2.2.0", optional = true }
@@ -34,7 +33,6 @@ tokio-test = "0.4.3"
 [features]
 build-binary = [
     "dep:anyhow",
-    "dep:async-recursion",
     "dep:async-walkdir",
     "dep:clap",
     "dep:futures-lite",


### PR DESCRIPTION
The prior logic unnecessarily recursed, in fact the underlying walker
handled recursion correctly already, and the code only needed to handle
skipping directories.

This commit also cleans up and simplifies the run_* functions' code by
pulling some things out into their own functions which report nice
error messages.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
