### PR TITLE
feat: Combine CLI id/tree cmds, add find cmd

### DIFF
--- a/omnibor/Cargo.toml
+++ b/omnibor/Cargo.toml
@@ -25,6 +25,7 @@ async-walkdir = { version = "1.0.0", optional = true }
 clap = { version = "4.5.1", features = ["derive"], optional = true }
 futures-lite = { version = "2.2.0", optional = true }
 serde_json = { version = "1.0.114", optional = true }
+smart-default = { version = "0.7.1", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["io-util", "fs"] }
@@ -37,6 +38,7 @@ build-binary = [
     "dep:clap",
     "dep:futures-lite",
     "dep:serde_json",
+    "dep:smart-default",
     "tokio/fs",
     "tokio/rt-multi-thread"
 ]


### PR DESCRIPTION
This commit combines the `id` and `tree` subcommands, and also adds a
new `find` subcommand. So there are two commands:

- `id`: If given a file, ID it. If given a directory, recursively ID
  all files within it.
- `find`: Given a `gitoid` URL and a root directory, search under the
  root dir to find a file that matches the `gitoid`.

This commit also cleans up the code a bit.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
