### PR TITLE
chore: Config cargo-release commit message.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ pr-run-mode = "plan"
 inherits = "release"
 lto = "thin"
 
+
+[workspace.metadata.release]
+pre-release-commit-message = "chore: Release"


### PR DESCRIPTION
This change is intended to make `cargo release` use a Conventional
Commit compatible prefix when committing new releases.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
