### PR TITLE
feat: Implemented async printing in CLI

### DIFF
--- a/omnibor/Cargo.toml
+++ b/omnibor/Cargo.toml
@@ -40,6 +40,10 @@ build-binary = [
     "dep:serde_json",
     "dep:smart-default",
     "tokio/fs",
+    "tokio/io-std",
+    "tokio/macros",
+    "tokio/rt",
+    "tokio/sync",
     "tokio/rt-multi-thread"
 ]
 


### PR DESCRIPTION
This commit implements asynchronous printing in the CLI by having a
printing task that handles all printing, and having other tasks just
send messages to say they want something printed. This ensures nothing
interleaves while doing async printing, and that printing doesn't block
the workers.

This commit also introduces a structured Msg type for what gets printed,
handling the different cases of stdout vs. stderr and plain vs. JSON
output.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
