### PR TITLE
Ensured the print buffer is flushed before program exit, short printing

### DIFF
--- a/omnibor/Cargo.toml
+++ b/omnibor/Cargo.toml
@@ -45,6 +45,7 @@ build-binary = [
     "tokio/macros",
     "tokio/rt",
     "tokio/sync",
+    "tokio/time",
     "tokio/rt-multi-thread"
 ]
 


### PR DESCRIPTION
## Description

Added an option to only print the gitoid in "plain" output mode so that it can be passed directly to `curl` or otherwise be used in CLI applications.

Also, ensured the print buffer (an async thread) has completed outputting before the program is terminated. This addressed a bug when using `curl https://goatrodeo.org/omnibor/$(omnibor id ...)`

## Related Issue
Okay... I'm being bad. I didn't create an issue.

## Motivation and Context
Make the tool CLI friendly

## How Has This Been Tested?
Smoke test
