### PR TITLE
fix: Fix 'find' command short format.

### DIFF
--- a/omnibor/src/bin/omnibor/find.rs
+++ b/omnibor/src/bin/omnibor/find.rs
@@ -3,7 +3,6 @@
 use crate::cli::FindArgs;
 use crate::cli::SelectedHash;
 use crate::fs::*;
-use crate::print::Msg;
 use crate::print::PrinterCmd;
 use anyhow::Result;
 use async_walkdir::WalkDir;
@@ -37,7 +36,7 @@ pub async fn run(tx: &Sender<PrinterCmd>, args: &FindArgs) -> Result<()> {
                 let file_url = hash_file(SelectedHash::Sha256, &mut file, &path).await?;
 
                 if url == file_url {
-                    tx.send(PrinterCmd::id(&path, &url, *format)).await?;
+                    tx.send(PrinterCmd::find(&path, &url, *format)).await?;
                     return Ok(());
                 }
             }


### PR DESCRIPTION
Previously, the 'short' format on the 'find' command would actually
just re-print the hash that was provided, as it was treating the
output identically to the `id` command. This commit introduces a new
`Msg` constructor for the `find` version, which is identical to the
`id` version for the `plain` and `json` formats, but which _only_
prints the found path in the 'short' format.

It also slightly refactors printing in `Msg` to avoid the trait object
and instead just match on the message status to decide where to write.

Signed-off-by: GitHub <noreply@github.com>
