### PR TITLE
feat: Add size test for ArtifactId<Sha256>

### DIFF
--- a/omnibor/Cargo.toml
+++ b/omnibor/Cargo.toml
@@ -31,6 +31,8 @@ smart-default = { version = "0.7.1", optional = true }
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["io-util", "fs"] }
 tokio-test = "0.4.3"
+# Match the version used in the `gitoid` crate.
+digest = "0.10.7"
 
 [features]
 build-binary = [

--- a/omnibor/src/lib.rs
+++ b/omnibor/src/lib.rs
@@ -46,6 +46,8 @@ pub(crate) mod sealed;
 mod artifact_id;
 mod error;
 mod supported_hash;
+#[cfg(test)]
+mod test;
 
 pub(crate) use crate::error::Result;
 

--- a/omnibor/src/test.rs
+++ b/omnibor/src/test.rs
@@ -1,0 +1,17 @@
+//! Tests against the OmniBOR crate as a whole.
+
+use crate::ArtifactId;
+use crate::Sha256;
+use crate::SupportedHash;
+use digest::OutputSizeUser;
+use gitoid::HashAlgorithm;
+use std::mem::size_of;
+
+/// Get the underlying 'Digest'-implementing type for the Sha256 algorithm.
+type Sha256Alg = <<Sha256 as SupportedHash>::HashAlgorithm as HashAlgorithm>::Alg;
+
+/// ArtifactID should be exactly 32 bytes, the size of the buffer.
+#[test]
+fn artifact_id_sha256_size() {
+    assert_eq!(size_of::<ArtifactId<Sha256>>(), Sha256Alg::output_size());
+}


### PR DESCRIPTION
This commit adds a new test for the ArtifactId<Sha256> type to ensure
the size of the ID is exactly the size of the buffer needed for the
SHA-256 hash, and nothing more.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
