### PR TITLE
fix: Don't stop looking at first 'find' match

### DIFF
--- a/omnibor/src/bin/omnibor/find.rs
+++ b/omnibor/src/bin/omnibor/find.rs
@@ -37,7 +37,6 @@ pub async fn run(tx: &Sender<PrinterCmd>, args: &FindArgs) -> Result<()> {
 
                 if url == file_url {
                     tx.send(PrinterCmd::find(&path, &url, *format)).await?;
-                    return Ok(());
                 }
             }
         }


### PR DESCRIPTION
Previously, we'd incorrectly return, and therefore stop looking, when
a match was found in the 'find' command. This misses that there may be
duplicate files, and we want to report all of them.

This commit just removes the return, so we now keep searching and
report all matches.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
