### PR TITLE
feat: Optionally-implement serde for ArtifactId

### DIFF
--- a/omnibor/Cargo.toml
+++ b/omnibor/Cargo.toml
@@ -18,6 +18,7 @@ edition.workspace = true
 gitoid = "0.5.0"
 tokio = { version = "1.36.0", features = ["io-util"] }
 url = "2.5.0"
+serde = { version = "1.0.197", optional = true }
 
 # Binary-only dependencies
 
@@ -33,8 +34,14 @@ tokio = { version = "1.36.0", features = ["io-util", "fs"] }
 tokio-test = "0.4.3"
 # Match the version used in the `gitoid` crate.
 digest = "0.10.7"
+serde_test = "1.0.176"
 
 [features]
+
+# Support serde serialization and deserialization
+serde = ["dep:serde"]
+
+# Used to build the `omnibor` CLI.
 build-binary = [
     "dep:anyhow",
     "dep:async-walkdir",

--- a/omnibor/src/bin/omnibor/find.rs
+++ b/omnibor/src/bin/omnibor/find.rs
@@ -16,7 +16,7 @@ pub async fn run(tx: &Sender<PrinterCmd>, args: &FindArgs) -> Result<()> {
     let FindArgs { url, path, format } = args;
 
     // TODO(alilleybrinker): Correctly handle possible future hash formats.
-    let id = ArtifactId::<Sha256>::id_url(url.clone())?;
+    let id = ArtifactId::<Sha256>::try_from_url(url.clone())?;
     let url = id.url();
 
     let mut entries = WalkDir::new(&path);

--- a/omnibor/src/error.rs
+++ b/omnibor/src/error.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::result::Result as StdResult;
+use url::ParseError as UrlError;
 
 pub type Result<T> = StdResult<T, Error>;
 
@@ -14,12 +15,16 @@ pub type Result<T> = StdResult<T, Error>;
 pub enum Error {
     /// An error arising from the underlying `gitoid` crate.
     GitOid(GitOidError),
+
+    /// An error arising from URL parsing.
+    Url(UrlError),
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
             Error::GitOid(inner) => write!(f, "{}", inner),
+            Error::Url(inner) => write!(f, "{}", inner),
         }
     }
 }
@@ -28,6 +33,7 @@ impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
             Error::GitOid(inner) => Some(inner),
+            Error::Url(inner) => Some(inner),
         }
     }
 }
@@ -35,5 +41,11 @@ impl StdError for Error {
 impl From<GitOidError> for Error {
     fn from(inner: GitOidError) -> Error {
         Error::GitOid(inner)
+    }
+}
+
+impl From<UrlError> for Error {
+    fn from(inner: UrlError) -> Self {
+        Error::Url(inner)
     }
 }

--- a/omnibor/src/test.rs
+++ b/omnibor/src/test.rs
@@ -15,3 +15,19 @@ type Sha256Alg = <<Sha256 as SupportedHash>::HashAlgorithm as HashAlgorithm>::Al
 fn artifact_id_sha256_size() {
     assert_eq!(size_of::<ArtifactId<Sha256>>(), Sha256Alg::output_size());
 }
+
+#[cfg(feature = "serde")]
+mod serde_test {
+    use crate::ArtifactId;
+    use crate::Sha256;
+    use serde_test::assert_tokens;
+    use serde_test::Token;
+
+    #[test]
+    fn valid_artifact_id_ser_de() {
+        let id = ArtifactId::<Sha256>::id_str("hello, world");
+
+        // This validates both serialization and deserialization.
+        assert_tokens(&id, &[Token::Str("gitoid:blob:sha256:7d0be525d6521168c74051e5ab1b99e3b6d1c962fba763818f1954ab9e1c821a")]);
+    }
+}


### PR DESCRIPTION
This commit adds an optional "serde" feature to the `omnibor` library
crate which implements `serde::Serialize` and `serde::Deserialize`
for `ArtifactId` if enabled. It also adds a test with the `serde_test`
crate to validate that it serializes as expected and roundtrips
back to the original value correctly.

This commit also cleans up some constructor names and modifies some
trait impls for correctness. In particular `FromStr` now performs
`Url::parse` followed by `ArtifactId::try_from_url` instead of running
`ArtifactId::id_str`, as this seems less surprising than hashing the
provided string.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
