### PR TITLE
feat: Introduce gitoid crate features incl. std.

### DIFF
--- a/gitoid/Cargo.toml
+++ b/gitoid/Cargo.toml
@@ -6,40 +6,84 @@ name = "gitoid"
 readme = "README.md"
 repository = "https://github.com/omnibor/omnibor-rs"
 version = "0.5.1"
-
 homepage.workspace = true
 license.workspace = true
 edition.workspace = true
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [dependencies]
 
-## Core Dependencies
+# no_std compatible dependencies.
 
-# Match the version used in sha1 and sha2.
-digest = "0.10.7"
-format-bytes = "0.3.0"
-# Match the version used in sha1, sha2, and digest.
-generic-array = "0.14.7"
+# NOTE: Must match the version used in the hash crate.
+#
+# Technically, we could rely on the re-export from one of those crates,
+# but since all the hash crates are optional dependencies our usage code
+# within the 'gitoid' crate would be more complex to handle the possibility
+# for any/all of them to be missing. It's simpler to just specify it here
+# so we know we always get the crate.
+digest = { version = "0.10.7" }
+sha1 = { version = "0.10.6", default-features = false, optional = true }
+sha1collisiondetection = { version = "0.3.3", default-features = false, features = ["digest-trait"], optional = true }
+sha2 = { version = "0.10.8", default-features = false, optional = true }
 
-## Hash Algorithms
+# std-requiring dependencies.
 
-sha1 = { version = "0.10.6", default-features = false, features = ["std"] }
-sha1collisiondetection = "0.3.3"
-sha2 = { version = "0.10.8", default-features = false }
-
-## Async Support
-
-tokio = { version = "1.36.0", features = ["io-util"] }
-
-## Representations
-
-hex = { version = "0.4.3", default-features = false, features = ["std"] }
-url = "2.4.1"
+format-bytes = { version = "0.3.0", optional = true }
+hex = { version = "0.4.3", optional = true }
+tokio = { version = "1.36.0", features = ["io-util"], optional = true }
+url = { version = "2.4.1", optional = true }
 
 [dev-dependencies]
 
 # Need "rt" and "fs" additionally for tests.
 tokio = { version = "1.36.0", features = ["io-util", "fs", "rt", "rt-multi-thread"] }
+
+[features]
+
+# By default, you get:
+#
+# - Hashes: sha1, sha1cd, sha256.
+# - Async: ability to asynchronously produce GitOIDs using the Tokio runtime.
+# - Hex: ability to print a GitOid with a hexadecimal hash representation.
+# - Url: ability to convert a GitOid to and from a gitoid-scheme URL.
+default = ["async", "hex", "sha1", "sha1cd", "sha256", "std", "url"]
+
+# Async support is optional. That said, it's currently _only_ with Tokio,
+# meaning you'd need to handle integrating with any other async runtime
+# yourself. In the future it may be nice to make our async support fully
+# generic and not specific to a given runtime.
+#
+# Note also that async support implies using the standard library, as Tokio
+# is not `no_std`-compatible.
+async = ["dep:tokio", "std"]
+
+# Get the ability to print the contents of the hash buffer as a hexadecimal string.
+#
+# This relies on `std` as we don't currently expose a `no_std`-compatible
+# variant of our API's which use `hex`.
+hex = ["dep:hex", "std"]
+
+# All hash algorithms are optional, though you need to have at least one
+# algorithm turned on for this crate to be useful. This is intended to
+# just let you avoid paying the cost of algorithms you don't use.
+sha1 = ["dep:sha1"]
+sha1cd = ["dep:sha1collisiondetection"]
+sha256 = ["dep:sha2"]
+
+# Get standard library support.
+#
+# This feature is enabled by default. You can disable it to run in
+# environments without `std`, usually embedded environments.
+std = [
+    "digest/std",
+    "sha1?/std",
+    "sha1collisiondetection?/std",
+    "sha2?/std",
+    "dep:format-bytes"
+]
+
+# Get the ability to construct and get out URLs.
+#
+# This relies on `std` as the `url` crate isn't `no_std`-compatible.
+# This also relies on `hex` as the URL includes the hex-encoded hash.
+url = ["dep:url", "hex", "std"]

--- a/gitoid/src/error.rs
+++ b/gitoid/src/error.rs
@@ -4,10 +4,15 @@ use core::fmt::Display;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
 use core::result::Result as StdResult;
+#[cfg(feature = "hex")]
 use hex::FromHexError as HexError;
+#[cfg(feature = "std")]
 use std::error::Error as StdError;
+#[cfg(feature = "std")]
 use std::io::Error as IoError;
+#[cfg(feature = "url")]
 use url::ParseError as UrlError;
+#[cfg(feature = "url")]
 use url::Url;
 
 /// A `Result` with `gitoid::Error` as the error type.
@@ -16,26 +21,46 @@ pub(crate) type Result<T> = StdResult<T, Error>;
 /// An error arising during `GitOid` construction or use.
 #[derive(Debug)]
 pub enum Error {
+    #[cfg(feature = "url")]
     /// Tried to construct a `GitOid` from a `Url` with a scheme besides `gitoid`.
     InvalidScheme(Url),
+
+    #[cfg(feature = "url")]
     /// Tried to construct a `GitOid` from a `Url` without an `ObjectType` in it.
     MissingObjectType(Url),
+
+    #[cfg(feature = "url")]
     /// Tried to construct a `GitOid` from a `Url` without a `HashAlgorithm` in it.
     MissingHashAlgorithm(Url),
+
+    #[cfg(feature = "url")]
     /// Tried to construct a `GitOid` from a `Url` without a hash in it.
     MissingHash(Url),
+
     /// Tried to parse an unknown object type.
-    UnknownObjectType(String),
+    UnknownObjectType,
+
     /// The expected object type didn't match the provided type.
-    MismatchedObjectType { expected: String, observed: String },
+    MismatchedObjectType { expected: &'static str },
+
     /// The expected hash algorithm didn't match the provided algorithm.
-    MismatchedHashAlgorithm { expected: String, observed: String },
+    MismatchedHashAlgorithm { expected: &'static str },
+
     /// The expected size of a hash for an algorithm didn't match the provided size.
     UnexpectedHashLength { expected: usize, observed: usize },
+
+    /// The amount of data read didn't match the expected amount of data
+    UnexpectedReadLength { expected: usize, observed: usize },
+
+    #[cfg(feature = "hex")]
     /// Tried to parse an invalid hex string.
     InvalidHex(HexError),
+
+    #[cfg(feature = "url")]
     /// Could not construct a valid URL based on the `GitOid` data.
     Url(UrlError),
+
+    #[cfg(feature = "std")]
     /// Could not perform the IO operations necessary to construct the `GitOid`.
     Io(IoError),
 }
@@ -43,23 +68,30 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
+            #[cfg(feature = "url")]
             Error::InvalidScheme(url) => write!(f, "invalid scheme in URL '{}'", url.scheme()),
+
+            #[cfg(feature = "url")]
             Error::MissingObjectType(url) => write!(f, "missing object type in URL '{}'", url),
+
+            #[cfg(feature = "url")]
             Error::MissingHashAlgorithm(url) => {
                 write!(f, "missing hash algorithm in URL '{}'", url)
             }
+
+            #[cfg(feature = "url")]
             Error::MissingHash(url) => write!(f, "missing hash in URL '{}'", url),
-            Error::UnknownObjectType(s) => write!(f, "unknown object type '{}'", s),
-            Error::MismatchedObjectType { expected, observed } => write!(
-                f,
-                "mismatched object type; expected '{}', got '{}'",
-                expected, observed
-            ),
-            Error::MismatchedHashAlgorithm { expected, observed } => write!(
-                f,
-                "mismatched hash algorithm; expected '{}', got '{}'",
-                expected, observed
-            ),
+
+            Error::UnknownObjectType => write!(f, "unknown object type"),
+
+            Error::MismatchedObjectType { expected } => {
+                write!(f, "mismatched object type; expected '{}'", expected,)
+            }
+
+            Error::MismatchedHashAlgorithm { expected } => {
+                write!(f, "mismatched hash algorithm; expected '{}'", expected)
+            }
+
             Error::UnexpectedHashLength { expected, observed } => {
                 write!(
                     f,
@@ -67,43 +99,76 @@ impl Display for Error {
                     expected, observed
                 )
             }
+
+            Error::UnexpectedReadLength { expected, observed } => {
+                write!(
+                    f,
+                    "unexpected read length; expected '{}', got '{}'",
+                    expected, observed
+                )
+            }
+
+            #[cfg(feature = "hex")]
             Error::InvalidHex(_) => write!(f, "invalid hex string"),
+
+            #[cfg(feature = "url")]
             Error::Url(e) => write!(f, "{}", e),
+
+            #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
     }
 }
 
+#[cfg(feature = "std")]
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Error::InvalidScheme(_)
-            | Error::MissingObjectType(_)
-            | Error::MissingHashAlgorithm(_)
-            | Error::MissingHash(_)
-            | Error::UnknownObjectType(_)
+            #[cfg(feature = "url")]
+            Error::InvalidScheme(_) => None,
+
+            #[cfg(feature = "url")]
+            Error::MissingObjectType(_) => None,
+
+            #[cfg(feature = "url")]
+            Error::MissingHashAlgorithm(_) => None,
+
+            #[cfg(feature = "url")]
+            Error::MissingHash(_) => None,
+
+            Error::UnknownObjectType
             | Error::MismatchedObjectType { .. }
             | Error::MismatchedHashAlgorithm { .. }
-            | Error::UnexpectedHashLength { .. } => None,
+            | Error::UnexpectedHashLength { .. }
+            | Error::UnexpectedReadLength { .. } => None,
+
+            #[cfg(feature = "hex")]
             Error::InvalidHex(e) => Some(e),
+
+            #[cfg(feature = "url")]
             Error::Url(e) => Some(e),
+
+            #[cfg(feature = "std")]
             Error::Io(e) => Some(e),
         }
     }
 }
 
+#[cfg(feature = "hex")]
 impl From<HexError> for Error {
     fn from(e: HexError) -> Error {
         Error::InvalidHex(e)
     }
 }
 
+#[cfg(feature = "url")]
 impl From<UrlError> for Error {
     fn from(e: UrlError) -> Error {
         Error::Url(e)
     }
 }
 
+#[cfg(feature = "std")]
 impl From<IoError> for Error {
     fn from(e: IoError) -> Error {
         Error::Io(e)

--- a/gitoid/src/hash_algorithm.rs
+++ b/gitoid/src/hash_algorithm.rs
@@ -6,9 +6,9 @@ use crate::GitOid;
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ops::Deref;
+use digest::block_buffer::generic_array::GenericArray;
 use digest::Digest;
 use digest::OutputSizeUser;
-use generic_array::GenericArray;
 
 /// Hash algorithms that can be used to make a [`GitOid`].
 ///
@@ -43,6 +43,7 @@ pub trait HashAlgorithm: Sealed {
     fn new() -> Self::Alg;
 }
 
+#[allow(unused_macros)]
 macro_rules! impl_hash_algorithm {
     ( $type:ident, $alg_ty:ty, $name:literal ) => {
         impl Sealed for $type {}
@@ -67,26 +68,32 @@ macro_rules! impl_hash_algorithm {
     };
 }
 
+#[cfg(feature = "sha1")]
 /// SHA-1 algorithm,
 pub struct Sha1 {
     #[doc(hidden)]
     _private: (),
 }
 
+#[cfg(feature = "sha1")]
 impl_hash_algorithm!(Sha1, sha1::Sha1, "sha1");
 
+#[cfg(feature = "sha256")]
 /// SHA-256 algorithm.
 pub struct Sha256 {
     #[doc(hidden)]
     _private: (),
 }
 
+#[cfg(feature = "sha256")]
 impl_hash_algorithm!(Sha256, sha2::Sha256, "sha256");
 
+#[cfg(feature = "sha1cd")]
 /// SHA-1Cd (collision detection) algorithm.
 pub struct Sha1Cd {
     #[doc(hidden)]
     _private: (),
 }
 
+#[cfg(feature = "sha1cd")]
 impl_hash_algorithm!(Sha1Cd, sha1collisiondetection::Sha1CD, "sha1cd");

--- a/gitoid/src/lib.rs
+++ b/gitoid/src/lib.rs
@@ -92,7 +92,7 @@
 //!
 //! ## Example
 //!
-//! ```rust
+//! ```text
 //! # use gitoid::{Sha256, Blob};
 //! type GitOid = gitoid::GitOid<Sha256, Blob>;
 //!
@@ -102,6 +102,13 @@
 //!
 //! [gitoid]: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
 //! [omnibor]: https://omnibor.io
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(any(feature = "sha1", feature = "sha1cd", feature = "sha256")))]
+compile_error!(
+    r#"At least one hash algorithm feature must be active: "sha1", "sha1cd", or "sha256""#
+);
 
 pub(crate) mod sealed;
 
@@ -118,8 +125,11 @@ pub(crate) use crate::error::Result;
 pub use crate::error::Error;
 pub use crate::gitoid::GitOid;
 pub use crate::hash_algorithm::HashAlgorithm;
+#[cfg(feature = "sha1")]
 pub use crate::hash_algorithm::Sha1;
+#[cfg(feature = "sha1cd")]
 pub use crate::hash_algorithm::Sha1Cd;
+#[cfg(feature = "sha256")]
 pub use crate::hash_algorithm::Sha256;
 pub use crate::object_type::Blob;
 pub use crate::object_type::Commit;

--- a/gitoid/src/tests.rs
+++ b/gitoid/src/tests.rs
@@ -1,9 +1,16 @@
+#![allow(unused_imports)]
+
 use super::*;
+#[cfg(feature = "std")]
 use std::fs::File;
+#[cfg(feature = "async")]
 use tokio::fs::File as AsyncFile;
+#[cfg(feature = "async")]
 use tokio::runtime::Runtime;
+#[cfg(feature = "url")]
 use url::Url;
 
+#[cfg(all(feature = "sha1", feature = "hex"))]
 #[test]
 fn generate_sha1_gitoid_from_bytes() {
     let input = b"hello world";
@@ -17,6 +24,7 @@ fn generate_sha1_gitoid_from_bytes() {
     );
 }
 
+#[cfg(all(feature = "sha1", feature = "std"))]
 #[test]
 fn generate_sha1_gitoid_from_buffer() -> Result<()> {
     let reader = File::open("test/data/hello_world.txt")?;
@@ -32,6 +40,7 @@ fn generate_sha1_gitoid_from_buffer() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "sha256")]
 #[test]
 fn generate_sha256_gitoid_from_bytes() {
     let input = b"hello world";
@@ -48,6 +57,7 @@ fn generate_sha256_gitoid_from_bytes() {
     );
 }
 
+#[cfg(all(feature = "sha256", feature = "std"))]
 #[test]
 fn generate_sha256_gitoid_from_buffer() -> Result<()> {
     let reader = File::open("test/data/hello_world.txt")?;
@@ -66,6 +76,7 @@ fn generate_sha256_gitoid_from_buffer() -> Result<()> {
     Ok(())
 }
 
+#[cfg(all(feature = "sha256", feature = "async"))]
 #[test]
 fn generate_sha256_gitoid_from_async_buffer() -> Result<()> {
     let runtime = Runtime::new()?;
@@ -87,6 +98,7 @@ fn generate_sha256_gitoid_from_async_buffer() -> Result<()> {
     })
 }
 
+#[cfg(feature = "sha256")]
 #[test]
 fn validate_uri() -> Result<()> {
     let content = b"hello world";
@@ -100,6 +112,7 @@ fn validate_uri() -> Result<()> {
     Ok(())
 }
 
+#[cfg(all(feature = "sha256", feature = "url"))]
 #[test]
 fn try_from_url_bad_scheme() {
     let url = Url::parse(
@@ -113,6 +126,7 @@ fn try_from_url_bad_scheme() {
     }
 }
 
+#[cfg(all(feature = "sha1", feature = "url"))]
 #[test]
 fn try_from_url_missing_object_type() {
     let url = Url::parse("gitoid:").unwrap();
@@ -123,19 +137,18 @@ fn try_from_url_missing_object_type() {
     }
 }
 
+#[cfg(all(feature = "sha1", feature = "url"))]
 #[test]
 fn try_from_url_bad_object_type() {
     let url = Url::parse("gitoid:whatever").unwrap();
 
     match GitOid::<Sha1, Blob>::from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
-        Err(e) => assert_eq!(
-            e.to_string(),
-            "mismatched object type; expected 'blob', got 'whatever'"
-        ),
+        Err(e) => assert_eq!(e.to_string(), "mismatched object type; expected 'blob'"),
     }
 }
 
+#[cfg(all(feature = "sha256", feature = "url"))]
 #[test]
 fn try_from_url_missing_hash_algorithm() {
     let url = Url::parse("gitoid:blob:").unwrap();
@@ -149,19 +162,18 @@ fn try_from_url_missing_hash_algorithm() {
     }
 }
 
+#[cfg(all(feature = "sha1", feature = "url"))]
 #[test]
 fn try_from_url_bad_hash_algorithm() {
     let url = Url::parse("gitoid:blob:sha10000").unwrap();
 
     match GitOid::<Sha1, Blob>::from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
-        Err(e) => assert_eq!(
-            e.to_string(),
-            "mismatched hash algorithm; expected 'sha1', got 'sha10000'"
-        ),
+        Err(e) => assert_eq!(e.to_string(), "mismatched hash algorithm; expected 'sha1'"),
     }
 }
 
+#[cfg(all(feature = "sha256", feature = "url"))]
 #[test]
 fn try_from_url_missing_hash() {
     let url = Url::parse("gitoid:blob:sha256:").unwrap();
@@ -172,6 +184,7 @@ fn try_from_url_missing_hash() {
     }
 }
 
+#[cfg(all(feature = "sha256", feature = "url"))]
 #[test]
 fn try_url_roundtrip() {
     let url = Url::parse(
@@ -180,9 +193,5 @@ fn try_url_roundtrip() {
     .unwrap();
     let gitoid = GitOid::<Sha256, Blob>::from_url(url.clone()).unwrap();
     let output = gitoid.url();
-
-    eprintln!("{}", url);
-    eprintln!("{}", output);
-
     assert_eq!(url, output);
 }


### PR DESCRIPTION
This commit brings conditional compilation support to the `gitoid`
crate to enable users to run `gitoid` in `no_std` environments, and to
otherwise turn off dependencies that aren't needed.

The following are now supported:

- Running in a `no_std` environment.
- Turning off any hash algorithms you're not using (though you _must_
  enable at least one).
- Turning off async support with the Tokio runtime if you don't want
  async and/or use an async runtime besides Tokio.
- Turn off URL-interoperability if you don't want to work with URLs.
- Turn off hexadecimal printing if you don't want to display your
  `GitOid`s as URL strings (which involve hex-encoding).

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
