### PR TITLE
feat: Added 'serde' feature to `gitoid` crate

### DIFF
--- a/gitoid/Cargo.toml
+++ b/gitoid/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = { version = "0.10.8", default-features = false, optional = true }
 
 format-bytes = { version = "0.3.0", optional = true }
 hex = { version = "0.4.3", optional = true }
+serde = { version = "1.0.197", optional = true }
 tokio = { version = "1.36.0", features = ["io-util"], optional = true }
 url = { version = "2.4.1", optional = true }
 
@@ -37,6 +38,7 @@ url = { version = "2.4.1", optional = true }
 
 # Need "rt" and "fs" additionally for tests.
 tokio = { version = "1.36.0", features = ["io-util", "fs", "rt", "rt-multi-thread"] }
+serde_test = "1.0.176"
 
 [features]
 
@@ -46,7 +48,8 @@ tokio = { version = "1.36.0", features = ["io-util", "fs", "rt", "rt-multi-threa
 # - Async: ability to asynchronously produce GitOIDs using the Tokio runtime.
 # - Hex: ability to print a GitOid with a hexadecimal hash representation.
 # - Url: ability to convert a GitOid to and from a gitoid-scheme URL.
-default = ["async", "hex", "sha1", "sha1cd", "sha256", "std", "url"]
+# - Serde: ability to serialize and deserialize a GitOid to and from a URL.
+default = ["async", "hex", "serde", "sha1", "sha1cd", "sha256", "std", "url"]
 
 # Async support is optional. That said, it's currently _only_ with Tokio,
 # meaning you'd need to handle integrating with any other async runtime
@@ -62,6 +65,9 @@ async = ["dep:tokio", "std"]
 # This relies on `std` as we don't currently expose a `no_std`-compatible
 # variant of our API's which use `hex`.
 hex = ["dep:hex", "std"]
+
+# Get the ability to serialize and deserialize `GitOids`.
+serde = ["dep:serde", "url", "std"]
 
 # All hash algorithms are optional, though you need to have at least one
 # algorithm turned on for this crate to be useful. This is intended to

--- a/gitoid/src/gitoid.rs
+++ b/gitoid/src/gitoid.rs
@@ -14,6 +14,7 @@ use core::hash::Hash;
 use core::hash::Hasher;
 use core::marker::PhantomData;
 use core::ops::Not as _;
+use core::result::Result as StdResult;
 use core::str::FromStr;
 #[cfg(feature = "url")]
 use core::str::Split;
@@ -24,15 +25,17 @@ use digest::Digest;
 use digest::OutputSizeUser;
 #[cfg(feature = "std")]
 use format_bytes::format_bytes;
-
+#[cfg(feature = "serde")]
+use serde::{
+    de::{Deserializer, Error as DeserializeError, Visitor},
+    Deserialize, Serialize, Serializer,
+};
 #[cfg(feature = "std")]
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
-
 #[cfg(feature = "async")]
 use tokio::io::{
     AsyncBufReadExt as _, AsyncRead, AsyncSeek, AsyncSeekExt as _, BufReader as AsyncBufReader,
 };
-
 #[cfg(feature = "url")]
 use url::Url;
 
@@ -269,6 +272,56 @@ where
             H::NAME,
             self.as_hex()
         )
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<H, O> Serialize for GitOid<H, O>
+where
+    H: HashAlgorithm,
+    O: ObjectType,
+{
+    fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Serialize self as the URL string.
+        let self_as_url_str = self.url().to_string();
+        serializer.serialize_str(&self_as_url_str)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, H, O> Deserialize<'de> for GitOid<H, O>
+where
+    H: HashAlgorithm,
+    O: ObjectType,
+{
+    fn deserialize<D>(deserializer: D) -> StdResult<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Deserialize self from the URL string.
+        struct GitOidVisitor<H: HashAlgorithm, O: ObjectType>(PhantomData<H>, PhantomData<O>);
+
+        impl<'de, H: HashAlgorithm, O: ObjectType> Visitor<'de> for GitOidVisitor<H, O> {
+            type Value = GitOid<H, O>;
+
+            fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+                formatter.write_str("a gitoid-scheme URL")
+            }
+
+            fn visit_str<E>(self, value: &str) -> StdResult<Self::Value, E>
+            where
+                E: DeserializeError,
+            {
+                let url = Url::parse(value).map_err(E::custom)?;
+                let id = GitOid::try_from(url).map_err(E::custom)?;
+                Ok(id)
+            }
+        }
+
+        deserializer.deserialize_str(GitOidVisitor(PhantomData, PhantomData))
     }
 }
 

--- a/gitoid/src/tests.rs
+++ b/gitoid/src/tests.rs
@@ -9,6 +9,13 @@ use tokio::fs::File as AsyncFile;
 use tokio::runtime::Runtime;
 #[cfg(feature = "url")]
 use url::Url;
+#[cfg(feature = "serde")]
+use {
+    crate::Blob,
+    crate::GitOid,
+    crate::Sha256,
+    serde_test::{assert_tokens, Token},
+};
 
 #[cfg(all(feature = "sha1", feature = "hex"))]
 #[test]
@@ -194,4 +201,18 @@ fn try_url_roundtrip() {
     let gitoid = GitOid::<Sha256, Blob>::from_url(url.clone()).unwrap();
     let output = gitoid.url();
     assert_eq!(url, output);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn valid_gitoid_ser_de() {
+    let id = GitOid::<Sha256, Blob>::from_str("hello, world");
+
+    // This validates both serialization and deserialization.
+    assert_tokens(
+        &id,
+        &[Token::Str(
+            "gitoid:blob:sha256:7d0be525d6521168c74051e5ab1b99e3b6d1c962fba763818f1954ab9e1c821a",
+        )],
+    );
 }


### PR DESCRIPTION
This commit makes it possible to serialize and deserialize `GitOid`s
to and from their URL representation. So they get serialized as
URLs and deserialized from URLs.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>