### PR TITLE
fix(xtask): Correct version prefix to include 'v'

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -209,7 +209,7 @@ impl Step for CheckChangelogVersionBump {
                 "git cliff --config {config} --include-path {include} --bumped-version"
             )
             .read()?;
-            let prefix = format!("{}-", self.krate.name());
+            let prefix = format!("{}-v", self.krate.name());
             let stripped = raw.strip_prefix(&prefix).unwrap_or(&raw);
             Version::parse(stripped)?
         };


### PR DESCRIPTION
For the version comparison against what's expected by `git-cliff`, we
have to do some version string parsing, and this involves stripping
a prefix off which specifies the crate to _only_ get the actual
version number triple portion. The prior prefix used was missing the
letter "v" which is part of the prefix, and so parsing failed in
practice. This commit adds the missing part of the prefix.