### PR TITLE
fix(xtask): Don't quote CHANGELOG commit message.

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -309,7 +309,7 @@ impl Step for CommitChangelog {
         let msg = self.commit_msg();
         let changelog = pathbuf![self.krate.name(), "CHANGELOG.md"];
         cmd!(sh, "git add {changelog}").run()?;
-        cmd!(sh, "git commit --signoff -m \"{msg}\"").run()?;
+        cmd!(sh, "git commit --signoff -m {msg}").run()?;
         Ok(())
     }
 


### PR DESCRIPTION
Previously, in the "commit-changelog" step of the `cargo xtask release`
command, we'd wrap the commit message in quotes. Turns out this is
processed by Git in a way that means the actual commit message header
is committed wrapped in quotes, which means it won't parse as a
conventional commit, and also that it breaks rollback (because
rollback checks commit messages to ensure it doesn't actually un-commit
the wrong thing).

This commit removes the quote wrapping, which should ensure correct
parsing _and_ avoid broken rollback.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
