### PR TITLE
fix(xtask): Ignore missing files on rollback

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -284,7 +284,7 @@ impl Step for GenerateChangelog {
     fn undo(&mut self) -> Result<()> {
         let sh = Shell::new()?;
         let output = self.output();
-        cmd!(sh, "rm {output}").run()?;
+        cmd!(sh, "rm -f {output}").run()?;
         Ok(())
     }
 }


### PR DESCRIPTION
Previously, when rolling back the creation of the CHANGELOG file, we
would error out if the file couldn't be found for deletion. However,
if the commitment step afterward runs and gets rolled back, it will
un-commit and thereby delete the file anyway, so we can instead use
`rm -f` to _not_ error out if the file has already been deleted.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
