### PR TITLE
chore(xtask): Improve xtask logging format.

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,12 +3,13 @@ mod pipeline;
 mod release;
 
 use env_logger::{Builder as LoggerBuilder, Env};
-use std::io::Write as _;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
     LoggerBuilder::from_env(Env::default().default_filter_or("info"))
-        .format(|buf, record| writeln!(buf, "{:>10}: {}", record.level(), record.args()))
+        .format_timestamp(None)
+        .format_module_path(false)
+        .format_target(false)
         .init();
 
     let args = cli::args();


### PR DESCRIPTION
This modifies the construction of the logger to enable use of colors
again! Instead of writing our own custom formatter, this just modifies
configuration of the default formatter to not include information we
don't care about.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
