### PR TITLE
chore(xtask): Further document the `xtask` crate.

### DIFF
--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -1,6 +1,9 @@
+//! The `cargo xtask` Command Line Interface (CLI).
+
 use clap::{arg, builder::PossibleValue, value_parser, ArgMatches, Command, ValueEnum};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
+/// Define the CLI and parse arguments from the command line.
 pub fn args() -> ArgMatches {
     Command::new("xtask")
         .about("Task runner for the OmniBOR Rust workspace")
@@ -34,7 +37,10 @@ pub fn args() -> ArgMatches {
 /// The crate to release; can be "gitoid" or "omnibor"
 #[derive(Debug, Clone, Copy)]
 pub enum Crate {
+    /// The `gitoid` crate, found in the `gitoid` folder.
     GitOid,
+
+    /// The `omnibor` crate, found in the `omnibor` folder.
     OmniBor,
 }
 
@@ -53,6 +59,8 @@ impl Display for Crate {
     }
 }
 
+// This is needed for `clap` to be able to parse string values
+// into this `Crate` enum.
 impl ValueEnum for Crate {
     fn value_variants<'a>() -> &'a [Self] {
         &[Crate::GitOid, Crate::OmniBor]
@@ -66,8 +74,13 @@ impl ValueEnum for Crate {
 /// The version to bump; can be "major", "minor", or "patch"
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Bump {
+    /// Bump the major version.
     Major,
+
+    /// Bump the minor version.
     Minor,
+
+    /// Bump the patch version.
     Patch,
 }
 
@@ -80,7 +93,8 @@ impl Display for Bump {
         }
     }
 }
-
+// This is needed for `clap` to be able to parse string values
+// into this `Bump` enum.
 impl ValueEnum for Bump {
     fn value_variants<'a>() -> &'a [Self] {
         &[Bump::Major, Bump::Minor, Bump::Patch]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,5 @@
+//! A Task Runner for the OmniBOR Rust workspace.
+
 mod cli;
 mod pipeline;
 mod release;
@@ -22,6 +24,8 @@ fn main() -> ExitCode {
     if let Err(err) = res {
         log::error!("{}", err);
 
+        // We skip the first error in the chain because it's the
+        // exact error we've just printed.
         for err in err.chain().skip(1) {
             log::error!("\tcaused by: {}", err);
         }

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -1,3 +1,5 @@
+//! The `cargo xtask release` subcommand.
+
 use crate::{
     cli::{Bump, Crate},
     pipeline::{Pipeline, Step},
@@ -70,6 +72,7 @@ pub fn run(args: &ArgMatches) -> Result<()> {
     pipeline.run()
 }
 
+/// Get the information for a specific package.
 fn find_pkg(workspace_metadata: &Metadata, krate: Crate) -> Option<&Package> {
     for id in &workspace_metadata.workspace_members {
         let pkg = &workspace_metadata[id];
@@ -343,6 +346,14 @@ impl Step for ReleaseCrate {
         let krate = self.krate.name();
         let bump = self.bump.to_string();
         let execute = self.execute.then_some("--execute");
+
+        // TODO(alilleybrinker): It currently looks like this fails on networks
+        //                       which substitute in their own certificates,
+        //                       because Cargo is unable to validate the certificate.
+        //                       I believe this is because of how `xshell` isolates
+        //                       commands, which may be causing Cargo _not_ to pickup
+        //                       relevant configuration which would otherwise enable
+        //                       it to work on such a network.
         cmd!(
             sh,
             "cargo release -p {krate} --allow-branch main {execute...} {bump}"


### PR DESCRIPTION
This commit adds more documentation to the `xtask` crate, including a
note about a currently-known and as-yet-unresolved bug in the final
step of the `release` task on networks which inject their own
certificates.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
