### PR TITLE
chore: Document MSRV policy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ The OmniBOR Rust implementation is designed with the following goals in mind:
   matching of artifacts to identifiers or construction and analysis of artifact
   dependency graphs.
 
+## Minimum Supported Rust Version
+
+As the `gitoid` and `omnibor` packages are still under active development, we
+haven't yet committed to a minimum supported Rust version (MSRV), and instead
+recommend generally tracking Rust stable versions.
+
 ## Contributing
 
 Check out the [Contributing Guide][contributing].


### PR DESCRIPTION
We don't currently commit to an MSRV, and it's good to be explicit
about that and recommend that users of the crate track Rust stable
versions.

In the future, it would be good to have MSRVs for the `gitoid` crate,
`omnibor` library crate, and `omnibor` binary crate separately.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>