### PR TITLE
fix(xtask): Fix `execute` flag escaping.

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -345,7 +345,9 @@ impl Step for ReleaseCrate {
         let sh = Shell::new()?;
         let krate = self.krate.name();
         let bump = self.bump.to_string();
-        let execute = self.execute.then_some("--execute --no-confirm");
+
+        let possible_args = ["--execute", "--no-confirm"];
+        let execute = self.execute.then_some(&possible_args[..]).unwrap_or(&[]);
 
         cmd!(
             sh,


### PR DESCRIPTION
`xshell` uses some custom escaping logic under the hood that meant
trying to pass two args in a single string didn't work (they end up
as one quoted single arg, which `cargo-release` doesn't accept).

This commit modifies the flag inclusion logic to instead pass them
as a slice, which should expand correctly.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
