### PR TITLE
feat(xtask): Make `release` pickup Cargo creds.

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,5 +17,7 @@ env_logger = "0.11.2"
 log = "0.4.20"
 pathbuf = "1.0.0"
 semver = "1.0.22"
+serde = { version = "1.0.197", features = ["derive"] }
+toml = "0.8.10"
 which = "6.0.0"
 xshell = "0.2.5"


### PR DESCRIPTION
Previously, `cargo-release` being run in the sub-shell wasn't picking
up Cargo's authentication information, even if you'd previously run
'cargo login' to authenticate with the Crates.io registry. This commit
is intended to fix that by manually extracting the saved token from
Cargo's credentials file and passing it into the subshell using an
environment variable.

With how `xshell` works, this environment variable won't be logged
anywhere, so it's safe to pass the authentication token this way.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
