### PR TITLE
fix(xtask): Call `git-cliff` with `--bump`

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -283,7 +283,7 @@ impl Step for GenerateChangelog {
         sh.change_dir(&self.workspace_root);
         cmd!(
             sh,
-            "git cliff --config {config} --include-path {include} -o {output}"
+            "git cliff --config {config} --bump --include-path {include} -o {output}"
         )
         .run()?;
         Ok(())


### PR DESCRIPTION
This commit updates how `git-cliff` is called in the
`cargo xtask release` subcommand, to make sure it's called with the
`--bump` flag so that further changes are marked as being part of the
next version instead of being "Unreleased".

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
