### PR TITLE
feat(gitoid): Rename `GitOid` methods for clarity

### DIFF
--- a/gitoid/src/gitoid.rs
+++ b/gitoid/src/gitoid.rs
@@ -64,7 +64,7 @@ where
     O: ObjectType,
 {
     /// Create a new `GitOid` based on a slice of bytes.
-    pub fn from_bytes<B: AsRef<[u8]>>(content: B) -> GitOid<H, O> {
+    pub fn id_bytes<B: AsRef<[u8]>>(content: B) -> GitOid<H, O> {
         fn inner<H, O>(content: &[u8]) -> GitOid<H, O>
         where
             H: HashAlgorithm,
@@ -78,14 +78,13 @@ where
     }
 
     /// Create a `GitOid` from a UTF-8 string slice.
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str<S: AsRef<str>>(s: S) -> GitOid<H, O> {
+    pub fn id_str<S: AsRef<str>>(s: S) -> GitOid<H, O> {
         fn inner<H, O>(s: &str) -> GitOid<H, O>
         where
             H: HashAlgorithm,
             O: ObjectType,
         {
-            GitOid::from_bytes(s.as_bytes())
+            GitOid::id_bytes(s.as_bytes())
         }
 
         inner(s.as_ref())
@@ -93,14 +92,14 @@ where
 
     #[cfg(feature = "std")]
     /// Create a `GitOid` from a reader.
-    pub fn from_reader<R: Read + Seek>(mut reader: R) -> Result<GitOid<H, O>> {
+    pub fn id_reader<R: Read + Seek>(mut reader: R) -> Result<GitOid<H, O>> {
         let expected_length = stream_len(&mut reader)? as usize;
-        GitOid::from_reader_with_length(reader, expected_length)
+        GitOid::id_reader_with_length(reader, expected_length)
     }
 
     #[cfg(feature = "std")]
     /// Generate a `GitOid` from a reader, providing an expected length in bytes.
-    pub fn from_reader_with_length<R: Read>(
+    pub fn id_reader_with_length<R: Read>(
         reader: R,
         expected_length: usize,
     ) -> Result<GitOid<H, O>> {
@@ -109,16 +108,16 @@ where
 
     #[cfg(feature = "async")]
     /// Generate a `GitOid` from an asynchronous reader.
-    pub async fn from_async_reader<R: AsyncRead + AsyncSeek + Unpin>(
+    pub async fn id_async_reader<R: AsyncRead + AsyncSeek + Unpin>(
         mut reader: R,
     ) -> Result<GitOid<H, O>> {
         let expected_length = async_stream_len(&mut reader).await? as usize;
-        GitOid::from_async_reader_with_length(reader, expected_length).await
+        GitOid::id_async_reader_with_length(reader, expected_length).await
     }
 
     #[cfg(feature = "async")]
     /// Generate a `GitOid` from an asynchronous reader, providing an expected length in bytes.
-    pub async fn from_async_reader_with_length<R: AsyncRead + Unpin>(
+    pub async fn id_async_reader_with_length<R: AsyncRead + Unpin>(
         reader: R,
         expected_length: usize,
     ) -> Result<GitOid<H, O>> {
@@ -127,7 +126,7 @@ where
 
     #[cfg(feature = "url")]
     /// Construct a new `GitOid` from a `Url`.
-    pub fn from_url(url: Url) -> Result<GitOid<H, O>> {
+    pub fn try_from_url(url: Url) -> Result<GitOid<H, O>> {
         GitOid::try_from(url)
     }
 
@@ -174,7 +173,8 @@ where
     type Err = Error;
 
     fn from_str(s: &str) -> Result<GitOid<H, O>> {
-        Ok(GitOid::from_str(s))
+        let url = Url::parse(s)?;
+        GitOid::try_from_url(url)
     }
 }
 

--- a/gitoid/src/tests.rs
+++ b/gitoid/src/tests.rs
@@ -21,7 +21,7 @@ use {
 #[test]
 fn generate_sha1_gitoid_from_bytes() {
     let input = b"hello world";
-    let result = GitOid::<Sha1, Blob>::from_bytes(input);
+    let result = GitOid::<Sha1, Blob>::id_bytes(input);
 
     assert_eq!(result.as_hex(), "95d09f2b10159347eece71399a7e2e907ea3df4f");
 
@@ -35,7 +35,7 @@ fn generate_sha1_gitoid_from_bytes() {
 #[test]
 fn generate_sha1_gitoid_from_buffer() -> Result<()> {
     let reader = File::open("test/data/hello_world.txt")?;
-    let result = GitOid::<Sha1, Blob>::from_reader(reader)?;
+    let result = GitOid::<Sha1, Blob>::id_reader(reader)?;
 
     assert_eq!(result.as_hex(), "95d09f2b10159347eece71399a7e2e907ea3df4f");
 
@@ -51,7 +51,7 @@ fn generate_sha1_gitoid_from_buffer() -> Result<()> {
 #[test]
 fn generate_sha256_gitoid_from_bytes() {
     let input = b"hello world";
-    let result = GitOid::<Sha256, Blob>::from_bytes(input);
+    let result = GitOid::<Sha256, Blob>::id_bytes(input);
 
     assert_eq!(
         result.as_hex(),
@@ -68,7 +68,7 @@ fn generate_sha256_gitoid_from_bytes() {
 #[test]
 fn generate_sha256_gitoid_from_buffer() -> Result<()> {
     let reader = File::open("test/data/hello_world.txt")?;
-    let result = GitOid::<Sha256, Blob>::from_reader(reader)?;
+    let result = GitOid::<Sha256, Blob>::id_reader(reader)?;
 
     assert_eq!(
         result.as_hex(),
@@ -89,7 +89,7 @@ fn generate_sha256_gitoid_from_async_buffer() -> Result<()> {
     let runtime = Runtime::new()?;
     runtime.block_on(async {
         let reader = AsyncFile::open("test/data/hello_world.txt").await?;
-        let result = GitOid::<Sha256, Blob>::from_async_reader(reader).await?;
+        let result = GitOid::<Sha256, Blob>::id_async_reader(reader).await?;
 
         assert_eq!(
             result.as_hex(),
@@ -109,7 +109,7 @@ fn generate_sha256_gitoid_from_async_buffer() -> Result<()> {
 #[test]
 fn validate_uri() -> Result<()> {
     let content = b"hello world";
-    let gitoid = GitOid::<Sha256, Blob>::from_bytes(content);
+    let gitoid = GitOid::<Sha256, Blob>::id_bytes(content);
 
     assert_eq!(
         gitoid.url().to_string(),
@@ -127,7 +127,7 @@ fn try_from_url_bad_scheme() {
     )
     .unwrap();
 
-    match GitOid::<Sha256, Blob>::from_url(url) {
+    match GitOid::<Sha256, Blob>::try_from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
         Err(e) => assert_eq!(e.to_string(), "invalid scheme in URL 'whatever'"),
     }
@@ -138,7 +138,7 @@ fn try_from_url_bad_scheme() {
 fn try_from_url_missing_object_type() {
     let url = Url::parse("gitoid:").unwrap();
 
-    match GitOid::<Sha1, Blob>::from_url(url) {
+    match GitOid::<Sha1, Blob>::try_from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
         Err(e) => assert_eq!(e.to_string(), "missing object type in URL 'gitoid:'"),
     }
@@ -149,7 +149,7 @@ fn try_from_url_missing_object_type() {
 fn try_from_url_bad_object_type() {
     let url = Url::parse("gitoid:whatever").unwrap();
 
-    match GitOid::<Sha1, Blob>::from_url(url) {
+    match GitOid::<Sha1, Blob>::try_from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
         Err(e) => assert_eq!(e.to_string(), "mismatched object type; expected 'blob'"),
     }
@@ -160,7 +160,7 @@ fn try_from_url_bad_object_type() {
 fn try_from_url_missing_hash_algorithm() {
     let url = Url::parse("gitoid:blob:").unwrap();
 
-    match GitOid::<Sha256, Blob>::from_url(url) {
+    match GitOid::<Sha256, Blob>::try_from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
         Err(e) => assert_eq!(
             e.to_string(),
@@ -174,7 +174,7 @@ fn try_from_url_missing_hash_algorithm() {
 fn try_from_url_bad_hash_algorithm() {
     let url = Url::parse("gitoid:blob:sha10000").unwrap();
 
-    match GitOid::<Sha1, Blob>::from_url(url) {
+    match GitOid::<Sha1, Blob>::try_from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
         Err(e) => assert_eq!(e.to_string(), "mismatched hash algorithm; expected 'sha1'"),
     }
@@ -185,7 +185,7 @@ fn try_from_url_bad_hash_algorithm() {
 fn try_from_url_missing_hash() {
     let url = Url::parse("gitoid:blob:sha256:").unwrap();
 
-    match GitOid::<Sha256, Blob>::from_url(url) {
+    match GitOid::<Sha256, Blob>::try_from_url(url) {
         Ok(_) => panic!("gitoid parsing should fail"),
         Err(e) => assert_eq!(e.to_string(), "missing hash in URL 'gitoid:blob:sha256:'"),
     }
@@ -198,7 +198,7 @@ fn try_url_roundtrip() {
         "gitoid:blob:sha256:fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03",
     )
     .unwrap();
-    let gitoid = GitOid::<Sha256, Blob>::from_url(url.clone()).unwrap();
+    let gitoid = GitOid::<Sha256, Blob>::try_from_url(url.clone()).unwrap();
     let output = gitoid.url();
     assert_eq!(url, output);
 }
@@ -206,7 +206,7 @@ fn try_url_roundtrip() {
 #[cfg(feature = "serde")]
 #[test]
 fn valid_gitoid_ser_de() {
-    let id = GitOid::<Sha256, Blob>::from_str("hello, world");
+    let id = GitOid::<Sha256, Blob>::id_str("hello, world");
 
     // This validates both serialization and deserialization.
     assert_tokens(


### PR DESCRIPTION
This commit modifies the method names for a number of `GitOid` methods
to clarify when the thing being passed in is being _hashed_ (any of the
`id_*` methods) vs. when it's being used as an identity itself to
construct a `GitOid` from `try_from_url`.

This should hopefully make it clearer how to _use_ the `GitOid` type
correctly!

This commit also modifies the `FromStr` implementation to use
`try_from_url` under the hood instead of `id_str`, as it seems
surprising to think that `FromStr` would actually be hashing the
contents to produce an identifier rather than being a convenient
shorthand for first parsing and then constructing from a
`gitoid`-scheme URL.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
