### PR TITLE
chore(omnibor): Bump `gitoid`: 0.5.0 -> 0.7.0

### DIFF
--- a/omnibor/Cargo.toml
+++ b/omnibor/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 
 # Library dependencies
 
-gitoid = "0.5.0"
+gitoid = { version = "0.7.0", default-features = false, features = ["async", "hex", "serde", "sha256", "std", "url"] }
 tokio = { version = "1.36.0", features = ["io-util"] }
 url = "2.5.0"
 serde = { version = "1.0.197", optional = true }


### PR DESCRIPTION
This commit bumps our dependency on the `gitoid` crate from version
`0.5.0` to version `0.7.0`. To accomplish this, it:

- Modifies our serialization and deserialization logic for `ArtifactId`
  to delegate to the implementation on `gitoid::GitOid`
- Updates constructor calls to use the new names that changed between
  versions
- Updates the feature configuration of the `gitoid` dependency to no
  longer use `sha1` or `sha1cd` at all, reducing the number of total
  dependencies we need to import.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
