### PR TITLE
chore(omnibor): Teach `cargo-dist` to build CLI

### DIFF
--- a/omnibor/Cargo.toml
+++ b/omnibor/Cargo.toml
@@ -63,3 +63,12 @@ name = "omnibor"
 test = false
 bench = false
 required-features = ["build-binary"]
+
+# `cargo-dist` configuration.
+[package.metadata.dist]
+
+# Tell `cargo-dist` to use the `"build-binary"` feature when
+# building the OmniBOR CLI.
+#
+# See: https://opensource.axo.dev/cargo-dist/book/reference/config.html#features
+features = ["build-binary"]


### PR DESCRIPTION
This commit updates the `omnibor` package's configuration for
`cargo-dist` to specifically tell it to build the OmniBOR CLI using
the `"build-binary"` feature which it requires.

Huge thanks to @gankra for the guidance on how to do this!

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
