### PR TITLE
fix(xtask): Fix broken version parsing in release

### DIFF
--- a/omnibor-cli/src/print.rs
+++ b/omnibor-cli/src/print.rs
@@ -155,9 +155,7 @@ impl Msg {
             let status = Status::Error;
 
             match format {
-                Format::Plain | Format::Short => {
-                    Msg::plain(status, &format!("error: {}", error))
-                }
+                Format::Plain | Format::Short => Msg::plain(status, &format!("error: {}", error)),
                 Format::Json => Msg::json(status, json!({"error": error.to_string()})),
             }
         }

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -29,6 +29,13 @@ pub fn args() -> ArgMatches {
                         .default_value("false")
                         .value_parser(value_parser!(bool))
                         .help("not a dry run, actually execute the release"),
+                )
+                .arg(
+                    arg!(--"allow-dirty")
+                        .required(false)
+                        .default_value("false")
+                        .value_parser(value_parser!(bool))
+                        .help("allow Git worktree to be dirty"),
                 ),
         )
         .get_matches()
@@ -48,6 +55,8 @@ pub enum Crate {
 }
 
 impl Crate {
+    /// Get the name of the crate, as it should be shown in the CLI
+    /// and as it exists on the filesystem.
     pub fn name(&self) -> &'static str {
         match self {
             Crate::GitOid => "gitoid",


### PR DESCRIPTION
This commit updates how version parsing is done in
`cargo xtask release` to properly handle the new `omnibor-cli` crate.
It also adds an `--allow-dirty` flag to make it possible to iterate
on debugging the `release` task without having to first commit every
little edit. This flag, when active, just causes the `check-git-ready`
step to log a warning instead of erroring out if Git's worktree or
staging area are dirty.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
