### PR TITLE
feat(cli): Fallback to sync printing if needed.

### DIFF
--- a/omnibor-cli/Cargo.toml
+++ b/omnibor-cli/Cargo.toml
@@ -35,6 +35,8 @@ futures-lite = "2.2.0"
 serde_json = "1.0.114"
 smart-default = "0.7.1"
 url = "2.5.0"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [dependencies.clap]
 

--- a/omnibor-cli/src/id.rs
+++ b/omnibor-cli/src/id.rs
@@ -11,8 +11,10 @@ pub async fn run(tx: &Sender<PrinterCmd>, args: &IdArgs) -> Result<()> {
     let mut file = open_async_file(&args.path).await?;
 
     if file_is_dir(&file).await? {
-        id_directory(tx, &args.path, args.format, args.hash).await
+        id_directory(tx, &args.path, args.format, args.hash).await?;
     } else {
-        id_file(tx, &mut file, &args.path, args.format, args.hash).await
+        id_file(tx, &mut file, &args.path, args.format, args.hash).await?;
     }
+
+    Ok(())
 }


### PR DESCRIPTION
This commit updates the async printing logic to fallback to printing
synchronously if async printing fails for some reason. If _both_ fail,
then it'll panic.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
