### PR TITLE
chore(cli): Update `omnibor-cli/README.md`

### DIFF
--- a/omnibor-cli/README.md
+++ b/omnibor-cli/README.md
@@ -1,5 +1,15 @@
 
+<div align="center">
+
 # `omnibor-cli`
+
+<br>
+
+__Reproducible identifiers &amp; fine-grained build dependency tracking for software artifacts.__
+
+[![Website](https://img.shields.io/badge/website-omnibor.io-blue)](https://omnibor.io) [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/omnibor/omnibor-rs/blob/main/LICENSE)
+
+</div>
 
 This package defines an [OmniBOR] Command Line Interface, intended to enable
 easier generation and handling of OmniBOR identifiers and manifests.
@@ -8,11 +18,16 @@ easier generation and handling of OmniBOR identifiers and manifests.
 > This is currently a work-in-progress. Today, the `omnibor` CLI only supports
 > working with identifiers, not manifests.
 
+This command is intended to enable integration with shell scripts and other
+programs where the overhead of integrating directly with the `omnibor` crate
+through the C-language Foreign Function Interface (FFI) may not be worthwhile,
+and where the cost of running a shell to execute this CLI isn't problematic.
+
 ## Installation
 
-The OmniBOR CLI provides pre-built binaries for a number of platforms. Check
-out the release notes for the most recent [release] to get an installer for
-any of the following platforms:
+### Install from Release (recommended)
+
+The OmniBOR CLI provides pre-built binaries for the following platforms:
 
 - Apple Silicon macOS
 - Intel macOS
@@ -20,23 +35,59 @@ any of the following platforms:
 - x64 Linux
 - x64 MUSL Linux
 
-Huge shoutout to the folks at [Axo] for making [`cargo-dist`], which makes
-producing these binaries _extremely_ easy.
+For shell (Linux and macOS; requires `tar`, `unzip`, and either `curl` or `wget`):
 
-You can also try installing using [`cargo-binstall`], though we haven't
-tested that yet.
+```sh
+$ curl --proto '=https' --tlsv1.2 -LsSf "https://github.com/omnibor/omnibor-rs/releases/download/omnibor-cli-v0.6.0/omnibor-cli-installer.sh" | sh
+```
 
-If you want to build from source, and you have a recent enough Rust
-toolchain, you can:
+For Powershell (Windows; requires `tar`, `Expand-Archive`, and `Net.Webclient`):
 
-- Run `cargo install omnibor-cli`
-- Check out this repository and run `cargo install --path omnibor-cli`
+```powershell
+> powershell -c "irm https://github.com/omnibor/omnibor-rs/releases/download/omnibor-cli-v0.6.0/omnibor-cli-installer.ps1 | iex"
+```
 
-We currently do not commit to a Minimum Supported Rust Version (MSRV),
-and generally track stable. This may change in the future.
+> ![NOTE]
+> Huge shoutout to the folks at [Axo] for making [`cargo-dist`], which makes
+> producing these binaries _extremely_ easy.
+
+### Install with `cargo-binstall`
+
+You can also use [`cargo-binstall`] to install the OmniBOR CLI. This requires
+both `cargo` and `cargo-binstall` to be installed.
+
+```sh
+$ cargo binstall omnibor-cli
+```
+
+### Build from source (stable)
+
+You can build from source using Cargo, which requires a recent-enough
+Rust toolchain. We do not commit to a Minimum Supported Rust Version,
+and generally track stable currently.
+
+```sh
+$ cargo install omnibor-cli
+```
+
+### Build from source (unstable)
+
+Finally, you can build from the latest source in the repository itself.
+While we run continuous integration testing and try not to break the
+build in the repository, this runs a higher risk of brokenness or
+incompleteness of features relative to versions published to [Crates.io].
+
+This requires `git` to check out the repository, plus a recent-enough
+version of Rust. We do not commit to a Minimum Support Rust Version,
+and generally track stable currently.
+
+```sh
+# Run the following from the root of the repository after checking
+# the repository out with `git clone`.
+$ cargo install --path omnibor-cli
+```
 
 ## Examples
-
 
 
 <details>
@@ -174,11 +225,6 @@ The `short` format is recommended for piping or redirecting into other commands.
 
 The `json` format is recommended for more structured contexts, and can be
 passed to `jq` to manipulate.
-
-## Minimum Supported Rust Version (MSRV)
-
-This crate does not maintain a Minimum Supported Rust Version, and generally
-tracks the latest Rust stable version.
 
 ## License
 


### PR DESCRIPTION
This commit updates the `README.md` for the OmniBOR CLI to more
clearly explain how to install the tool, and to generally look nicer.

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>
