### PR TITLE
feat(gitoid): Add BoringSSL backend support for SHA-1 and SHA-256 in gitoid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Building
-        run: cargo build --verbose
+        run: cargo build --verbose --features=boring
       - name: Testing (Rust)
-        run: cargo test --verbose
+        run: cargo test --verbose --features=boring
       - name: Linting
-        run: cargo clippy --verbose
+        run: cargo clippy --verbose --features=boring
 
   conventional-commits:
       name: Conventional Commits

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Building
-        run: cargo build --verbose --features=boring
+        run: cargo build --verbose --features=boringssl
       - name: Testing (Rust)
-        run: cargo test --verbose --features=boring
+        run: cargo test --verbose --features=boringssl
       - name: Linting
-        run: cargo clippy --verbose --features=boring
+        run: cargo clippy --verbose --features=boringssl
 
   conventional-commits:
       name: Conventional Commits

--- a/gitoid/Cargo.toml
+++ b/gitoid/Cargo.toml
@@ -23,7 +23,9 @@ edition.workspace = true
 # so we know we always get the crate.
 digest = { version = "0.10.7" }
 sha1 = { version = "0.10.6", default-features = false, optional = true }
-sha1collisiondetection = { version = "0.3.3", default-features = false, features = ["digest-trait"], optional = true }
+sha1collisiondetection = { version = "0.3.3", default-features = false, features = [
+    "digest-trait",
+], optional = true }
 sha2 = { version = "0.10.8", default-features = false, optional = true }
 
 # std-requiring dependencies.
@@ -38,7 +40,12 @@ boring = { version = "4.6.0", optional = true }
 [dev-dependencies]
 
 # Need "rt" and "fs" additionally for tests.
-tokio = { version = "1.36.0", features = ["io-util", "fs", "rt", "rt-multi-thread"] }
+tokio = { version = "1.36.0", features = [
+    "io-util",
+    "fs",
+    "rt",
+    "rt-multi-thread",
+] }
 serde_test = "1.0.176"
 criterion = { version = "0.5.1" }
 
@@ -51,7 +58,18 @@ criterion = { version = "0.5.1" }
 # - Hex: ability to print a GitOid with a hexadecimal hash representation.
 # - Url: ability to convert a GitOid to and from a gitoid-scheme URL.
 # - Serde: ability to serialize and deserialize a GitOid to and from a URL.
-default = ["async", "hex", "serde", "std", "url"]
+# - Rustcrypto: use the RustCrypto crates as the cryptography backend.
+default = [
+    "async",
+    "hex",
+    "serde",
+    "std",
+    "url",
+    "rustcrypto",
+    "sha1",
+    "sha1cd",
+    "sha256",
+]
 
 # Async support is optional. That said, it's currently _only_ with Tokio,
 # meaning you'd need to handle integrating with any other async runtime
@@ -78,9 +96,6 @@ sha1 = ["dep:sha1"]
 sha1cd = ["dep:sha1collisiondetection"]
 sha256 = ["dep:sha2"]
 
-# Enable the rustcrypto feature.
-rustcrypto = []
-
 # Get standard library support.
 #
 # This feature is enabled by default. You can disable it to run in
@@ -90,7 +105,7 @@ std = [
     "sha1?/std",
     "sha1collisiondetection?/std",
     "sha2?/std",
-    "dep:format-bytes"
+    "dep:format-bytes",
 ]
 
 # Get the ability to construct and get out URLs.
@@ -99,8 +114,17 @@ std = [
 # This also relies on `hex` as the URL includes the hex-encoded hash.
 url = ["dep:url", "hex", "std"]
 
-# Enable the boring feature.
-boring = ["dep:boring", "sha1", "sha256"]
+# Enable using RustCrypto as a cryptography backend.
+rustcrypto = []
+
+# Enable using BoringSLL as a cryptography backend.
+#
+# NOTE: This unconditionally turns on the "sha1" and "sha256" features,
+# because the `boring` crate which provides the BoringSSL cryptography
+# implementations does not permit conditionally compiling those
+# implementations out. Since they're _always_ present, we might as well
+# use them unconditionally.
+boringssl = ["dep:boring", "sha1", "sha256"]
 
 [[bench]]
 name = "benchmark"

--- a/gitoid/Cargo.toml
+++ b/gitoid/Cargo.toml
@@ -33,12 +33,14 @@ hex = { version = "0.4.3", optional = true }
 serde = { version = "1.0.197", optional = true }
 tokio = { version = "1.36.0", features = ["io-util"], optional = true }
 url = { version = "2.4.1", optional = true }
+boring = { version = "4.6.0", optional = true }
 
 [dev-dependencies]
 
 # Need "rt" and "fs" additionally for tests.
 tokio = { version = "1.36.0", features = ["io-util", "fs", "rt", "rt-multi-thread"] }
 serde_test = "1.0.176"
+criterion = { version = "0.5.1" }
 
 [features]
 
@@ -93,3 +95,10 @@ std = [
 # This relies on `std` as the `url` crate isn't `no_std`-compatible.
 # This also relies on `hex` as the URL includes the hex-encoded hash.
 url = ["dep:url", "hex", "std"]
+
+# Enable the boring feature.
+boring = ["dep:boring", "sha1", "sha256"]
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/gitoid/Cargo.toml
+++ b/gitoid/Cargo.toml
@@ -51,7 +51,7 @@ criterion = { version = "0.5.1" }
 # - Hex: ability to print a GitOid with a hexadecimal hash representation.
 # - Url: ability to convert a GitOid to and from a gitoid-scheme URL.
 # - Serde: ability to serialize and deserialize a GitOid to and from a URL.
-default = ["async", "hex", "serde", "sha1", "sha1cd", "sha256", "std", "url"]
+default = ["async", "hex", "serde", "std", "url"]
 
 # Async support is optional. That said, it's currently _only_ with Tokio,
 # meaning you'd need to handle integrating with any other async runtime
@@ -77,6 +77,9 @@ serde = ["dep:serde", "url", "std"]
 sha1 = ["dep:sha1"]
 sha1cd = ["dep:sha1collisiondetection"]
 sha256 = ["dep:sha2"]
+
+# Enable the rustcrypto feature.
+rustcrypto = []
 
 # Get standard library support.
 #

--- a/gitoid/README.md
+++ b/gitoid/README.md
@@ -105,6 +105,26 @@ meaningful ways.
    the `sha1cd` algorithm. This is reflected in the `gitoid`-scheme URLs
    generated when using the `GitOid` type.
 
+## Boring Feature
+
+The `gitoid` crate supports using the BoringSSL cryptographic library for SHA-1
+and SHA-256 hashing through the `boring` feature. This can be useful for
+environments where BoringSSL is preferred or required for compliance reasons.
+
+### Enabling the Boring Feature
+
+To enable the `boring` feature, add the following to your `Cargo.toml`:
+
+```toml
+[dependencies]
+gitoid = { version = "0.7.1", features = ["boring"] }
+```
+
+When the `boring` feature is enabled, the crate will use BoringSSL's
+implementations of SHA-1 and SHA-256 instead of the default RustCrypto
+implementations. Note that `sha1cd` is not supported by the `boring` feature
+and will fall back to using the RustCrypto implementation.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate does not maintain a Minimum Supported Rust Version, and generally

--- a/gitoid/benches/benchmark.rs
+++ b/gitoid/benches/benchmark.rs
@@ -1,0 +1,79 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use gitoid::{GitOid, Sha1, Sha256, Blob};
+
+#[cfg(not(feature = "boring"))]
+fn bench_rustcrypto_sha1_small(c: &mut Criterion) {
+    bench_sha1_small(c, "GitOid RustCrypto SHA-1 11B");
+}
+#[cfg(feature = "boring")]
+fn bench_boring_sha1_small(c: &mut Criterion) {
+    bench_sha1_small(c, "GitOid BoringSSL SHA-1 11B");
+}
+
+fn bench_sha1_small(c: &mut Criterion, name: &str) {
+    let input = b"hello world";
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let _ = GitOid::<Sha1, Blob>::id_bytes(black_box(input));
+        })
+    });
+}
+
+#[cfg(not(feature = "boring"))]
+fn bench_rustcrypto_sha256_small(c: &mut Criterion) {
+    bench_sha256_small(c, "GitOid RustCrypto SHA-256 11B");
+}
+#[cfg(feature = "boring")]
+fn bench_boring_sha256_small(c: &mut Criterion) {
+    bench_sha256_small(c, "GitOid BoringSSL SHA-256 11B");
+}
+fn bench_sha256_small(c: &mut Criterion, name: &str) {
+    let input = b"hello world";
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let _ = GitOid::<Sha256, Blob>::id_bytes(black_box(input));
+        })
+    });
+}
+
+#[cfg(not(feature = "boring"))]
+fn bench_rustcrypto_sha1_large(c: &mut Criterion) {
+    bench_sha1_large(c, "GitOid RustCrypto SHA-1 100MB");
+}
+#[cfg(feature = "boring")]
+fn bench_boring_sha1_large(c: &mut Criterion) {
+    bench_sha1_large(c, "GitOid BoringSSL SHA-1 100MB");
+}
+
+fn bench_sha1_large(c: &mut Criterion, name: &str) {
+    let input = &[0; 1024*1024*100]; // 100 MB
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let _ = GitOid::<Sha1, Blob>::id_bytes(black_box(input));
+        })
+    });
+}
+
+#[cfg(not(feature = "boring"))]
+fn bench_rustcrypto_sha256_large(c: &mut Criterion) {
+    bench_sha256_large(c, "GitOid RustCrypto SHA-256 100MB");
+}
+#[cfg(feature = "boring")]
+fn bench_boring_sha256_large(c: &mut Criterion) {
+    bench_sha256_large(c, "GitOid BoringSSL SHA-256 100MB");
+}
+
+fn bench_sha256_large(c: &mut Criterion, name: &str) {
+    let input = &[0; 1024*1024*100]; // 100 MB
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let _ = GitOid::<Sha256, Blob>::id_bytes(black_box(input));
+        })
+    });
+}
+
+#[cfg(not(feature = "boring"))]
+criterion_group!(benches, bench_rustcrypto_sha1_small, bench_rustcrypto_sha256_small, bench_rustcrypto_sha1_large, bench_rustcrypto_sha256_large);
+#[cfg(feature = "boring")]
+criterion_group!(benches, bench_boring_sha1_small, bench_boring_sha256_small, bench_boring_sha1_large, bench_boring_sha256_large);
+criterion_main!(benches);

--- a/gitoid/benches/benchmark.rs
+++ b/gitoid/benches/benchmark.rs
@@ -1,79 +1,136 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use gitoid::{GitOid, Sha1, Sha256, Blob};
+use criterion::black_box;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+#[cfg(feature = "boringssl")]
+use gitoid::boringssl::Sha1 as BoringSha1;
+#[cfg(feature = "boringssl")]
+use gitoid::boringssl::Sha256 as BoringSha256;
+#[cfg(all(feature = "rustcrypto", feature = "sha1"))]
+use gitoid::rustcrypto::Sha1 as RustSha1;
+#[cfg(all(feature = "rustcrypto", feature = "sha256"))]
+use gitoid::rustcrypto::Sha256 as RustSha256;
+use gitoid::Blob;
+use gitoid::GitOid;
 
-#[cfg(not(feature = "boring"))]
+#[cfg(not(any(feature = "rustcrypto", feature = "boringssl",)))]
+compile_error!(
+    r#"At least one cryptography backend must be active: "rustcrypto" and/or "boringssl""#
+);
+
+#[cfg(feature = "rustcrypto")]
 fn bench_rustcrypto_sha1_small(c: &mut Criterion) {
-    bench_sha1_small(c, "GitOid RustCrypto SHA-1 11B");
+    let name = "GitOid RustCrypto SHA-1 11B";
+    let input = b"hello world";
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let _ = GitOid::<RustSha1, Blob>::id_bytes(black_box(input));
+        })
+    });
 }
-#[cfg(feature = "boring")]
+
+#[cfg(feature = "boringssl")]
 fn bench_boring_sha1_small(c: &mut Criterion) {
-    bench_sha1_small(c, "GitOid BoringSSL SHA-1 11B");
-}
-
-fn bench_sha1_small(c: &mut Criterion, name: &str) {
+    let name = "GitOid BoringSSL SHA-1 11B";
     let input = b"hello world";
     c.bench_function(name, |b| {
         b.iter(|| {
-            let _ = GitOid::<Sha1, Blob>::id_bytes(black_box(input));
+            let _ = GitOid::<BoringSha1, Blob>::id_bytes(black_box(input));
         })
     });
 }
 
-#[cfg(not(feature = "boring"))]
+#[cfg(feature = "rustcrypto")]
 fn bench_rustcrypto_sha256_small(c: &mut Criterion) {
-    bench_sha256_small(c, "GitOid RustCrypto SHA-256 11B");
-}
-#[cfg(feature = "boring")]
-fn bench_boring_sha256_small(c: &mut Criterion) {
-    bench_sha256_small(c, "GitOid BoringSSL SHA-256 11B");
-}
-fn bench_sha256_small(c: &mut Criterion, name: &str) {
+    let name = "GitOid RustCrypto SHA-256 11B";
     let input = b"hello world";
     c.bench_function(name, |b| {
         b.iter(|| {
-            let _ = GitOid::<Sha256, Blob>::id_bytes(black_box(input));
+            let _ = GitOid::<RustSha256, Blob>::id_bytes(black_box(input));
         })
     });
 }
 
-#[cfg(not(feature = "boring"))]
+#[cfg(feature = "boringssl")]
+fn bench_boring_sha256_small(c: &mut Criterion) {
+    let name = "GitOid BoringSSL SHA-256 11B";
+    let input = b"hello world";
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let _ = GitOid::<BoringSha256, Blob>::id_bytes(black_box(input));
+        })
+    });
+}
+
+#[cfg(feature = "rustcrypto")]
 fn bench_rustcrypto_sha1_large(c: &mut Criterion) {
-    bench_sha1_large(c, "GitOid RustCrypto SHA-1 100MB");
+    let name = "GitOid RustCrypto SHA-1 100MB";
+    let input = &[0; 1024 * 1024 * 100]; // 100 MB
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let _ = GitOid::<RustSha1, Blob>::id_bytes(black_box(input));
+        })
+    });
 }
-#[cfg(feature = "boring")]
+
+#[cfg(feature = "boringssl")]
 fn bench_boring_sha1_large(c: &mut Criterion) {
-    bench_sha1_large(c, "GitOid BoringSSL SHA-1 100MB");
-}
-
-fn bench_sha1_large(c: &mut Criterion, name: &str) {
-    let input = &[0; 1024*1024*100]; // 100 MB
+    let name = "GitOid BoringSSL SHA-1 100MB";
+    let input = &[0; 1024 * 1024 * 100]; // 100 MB
     c.bench_function(name, |b| {
         b.iter(|| {
-            let _ = GitOid::<Sha1, Blob>::id_bytes(black_box(input));
+            let _ = GitOid::<BoringSha1, Blob>::id_bytes(black_box(input));
         })
     });
 }
 
-#[cfg(not(feature = "boring"))]
+#[cfg(feature = "rustcrypto")]
 fn bench_rustcrypto_sha256_large(c: &mut Criterion) {
-    bench_sha256_large(c, "GitOid RustCrypto SHA-256 100MB");
-}
-#[cfg(feature = "boring")]
-fn bench_boring_sha256_large(c: &mut Criterion) {
-    bench_sha256_large(c, "GitOid BoringSSL SHA-256 100MB");
-}
-
-fn bench_sha256_large(c: &mut Criterion, name: &str) {
-    let input = &[0; 1024*1024*100]; // 100 MB
+    let name = "GitOid RustCrypto SHA-256 100MB";
+    let input = &[0; 1024 * 1024 * 100]; // 100 MB
     c.bench_function(name, |b| {
         b.iter(|| {
-            let _ = GitOid::<Sha256, Blob>::id_bytes(black_box(input));
+            let _ = GitOid::<RustSha256, Blob>::id_bytes(black_box(input));
         })
     });
 }
 
-#[cfg(not(feature = "boring"))]
-criterion_group!(benches, bench_rustcrypto_sha1_small, bench_rustcrypto_sha256_small, bench_rustcrypto_sha1_large, bench_rustcrypto_sha256_large);
-#[cfg(feature = "boring")]
-criterion_group!(benches, bench_boring_sha1_small, bench_boring_sha256_small, bench_boring_sha1_large, bench_boring_sha256_large);
-criterion_main!(benches);
+#[cfg(feature = "boringssl")]
+fn bench_boring_sha256_large(c: &mut Criterion) {
+    let name = "GitOid BoringSSL SHA-256 100MB";
+    let input = &[0; 1024 * 1024 * 100]; // 100 MB
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let _ = GitOid::<BoringSha256, Blob>::id_bytes(black_box(input));
+        })
+    });
+}
+
+#[cfg(feature = "rustcrypto")]
+criterion_group!(
+    name = rustcrypto_benches;
+    config = Criterion::default();
+    targets = bench_rustcrypto_sha1_small,
+    bench_rustcrypto_sha256_small,
+    bench_rustcrypto_sha1_large,
+    bench_rustcrypto_sha256_large
+);
+
+#[cfg(feature = "boringssl")]
+criterion_group!(
+    name = boringssl_benches;
+    config = Criterion::default();
+    targets = bench_boring_sha1_small,
+    bench_boring_sha256_small,
+    bench_boring_sha1_large,
+    bench_boring_sha256_large
+);
+
+#[cfg(all(feature = "rustcrypto", feature = "boringssl"))]
+criterion_main!(rustcrypto_benches, boringssl_benches);
+
+#[cfg(all(feature = "rustcrypto", not(feature = "boringssl")))]
+criterion_main!(rustcrypto_benches);
+
+#[cfg(all(not(feature = "rustcrypto"), feature = "boringssl"))]
+criterion_main!(boringssl_benches);

--- a/gitoid/src/backend/boringssl.rs
+++ b/gitoid/src/backend/boringssl.rs
@@ -15,13 +15,14 @@ use digest::OutputSizeUser;
 use digest::Update;
 
 #[cfg(feature = "sha1")]
-/// SHA-1 algorithm,
+/// SHA-1 algorithm
 pub struct Sha256 {
     #[doc(hidden)]
     _private: (),
 }
 
 /// Boring SHA-256 implementation.
+#[doc(hidden)]
 pub struct BoringSha256 {
     hash: sha::Sha256,
 }
@@ -62,13 +63,14 @@ impl Default for BoringSha256 {
 }
 
 #[cfg(feature = "sha1")]
-/// SHA-1 algorithm,
+/// SHA-1 algorithm
 pub struct Sha1 {
     #[doc(hidden)]
     _private: (),
 }
 
 /// Boring SHA-1 implementation.
+#[doc(hidden)]
 pub struct BoringSha1 {
     hash: sha::Sha1,
 }

--- a/gitoid/src/backend/boringssl.rs
+++ b/gitoid/src/backend/boringssl.rs
@@ -1,11 +1,33 @@
+//! BoringSSL-based cryptography backend.
+
+use crate::impl_hash_algorithm;
+use crate::sealed::Sealed;
+use crate::HashAlgorithm;
 use boring::sha;
-use digest::{FixedOutput, HashMarker, Output, OutputSizeUser, Update};
-use digest::consts::{U20, U32};
+use digest::consts::U20;
+use digest::consts::U32;
+use digest::generic_array::GenericArray;
+use digest::Digest;
+use digest::FixedOutput;
+use digest::HashMarker;
+use digest::Output;
+use digest::OutputSizeUser;
+use digest::Update;
+
+#[cfg(feature = "sha1")]
+/// SHA-1 algorithm,
+pub struct Sha256 {
+    #[doc(hidden)]
+    _private: (),
+}
 
 /// Boring SHA-256 implementation.
 pub struct BoringSha256 {
     hash: sha::Sha256,
 }
+
+#[cfg(all(feature = "sha256", feature = "boringssl"))]
+impl_hash_algorithm!(Sha256, BoringSha256, "sha256");
 
 impl Update for BoringSha256 {
     fn update(&mut self, data: &[u8]) {
@@ -39,10 +61,20 @@ impl Default for BoringSha256 {
     }
 }
 
+#[cfg(feature = "sha1")]
+/// SHA-1 algorithm,
+pub struct Sha1 {
+    #[doc(hidden)]
+    _private: (),
+}
+
 /// Boring SHA-1 implementation.
 pub struct BoringSha1 {
     hash: sha::Sha1,
 }
+
+#[cfg(all(feature = "sha1", feature = "boringssl"))]
+impl_hash_algorithm!(Sha1, BoringSha1, "sha1");
 
 impl Update for BoringSha1 {
     fn update(&mut self, data: &[u8]) {

--- a/gitoid/src/backend/mod.rs
+++ b/gitoid/src/backend/mod.rs
@@ -1,0 +1,7 @@
+//! Cryptography backends, providing hash function implementations.
+
+#[cfg(feature = "boringssl")]
+pub mod boringssl;
+
+#[cfg(feature = "rustcrypto")]
+pub mod rustcrypto;

--- a/gitoid/src/backend/rustcrypto.rs
+++ b/gitoid/src/backend/rustcrypto.rs
@@ -1,0 +1,40 @@
+//! RustCrypto-based cryptography backend.
+
+use crate::impl_hash_algorithm;
+use crate::sealed::Sealed;
+#[cfg(doc)]
+use crate::GitOid;
+use crate::HashAlgorithm;
+use digest::generic_array::GenericArray;
+use digest::Digest;
+use digest::OutputSizeUser;
+
+#[cfg(feature = "sha1")]
+/// SHA-1 algorithm,
+pub struct Sha1 {
+    #[doc(hidden)]
+    _private: (),
+}
+
+#[cfg(feature = "sha1")]
+impl_hash_algorithm!(Sha1, sha1::Sha1, "sha1");
+
+#[cfg(feature = "sha1cd")]
+/// SHA-1Cd (collision detection) algorithm.
+pub struct Sha1Cd {
+    #[doc(hidden)]
+    _private: (),
+}
+
+#[cfg(feature = "sha1cd")]
+impl_hash_algorithm!(Sha1Cd, sha1collisiondetection::Sha1CD, "sha1cd");
+
+#[cfg(feature = "sha256")]
+/// SHA-256 algorithm.
+pub struct Sha256 {
+    #[doc(hidden)]
+    _private: (),
+}
+
+#[cfg(feature = "sha256")]
+impl_hash_algorithm!(Sha256, sha2::Sha256, "sha256");

--- a/gitoid/src/boring_sha.rs
+++ b/gitoid/src/boring_sha.rs
@@ -1,0 +1,92 @@
+#[cfg(feature = "boring")]
+use boring::sha;
+#[cfg(feature = "boring")]
+use digest::{FixedOutput, HashMarker, Output, OutputSizeUser, Update};
+#[cfg(feature = "boring")]
+use digest::consts::{U20, U32};
+
+/// Boring SHA-256 implementation.
+#[cfg(feature = "boring")]
+pub struct BoringSha256 {
+    hash: sha::Sha256,
+}
+
+#[cfg(feature = "boring")]
+impl Update for BoringSha256 {
+    fn update(&mut self, data: &[u8]) {
+        self.hash.update(data);
+    }
+}
+
+#[cfg(feature = "boring")]
+impl OutputSizeUser for BoringSha256 {
+    type OutputSize = U32;
+}
+
+#[cfg(feature = "boring")]
+impl FixedOutput for BoringSha256 {
+    fn finalize_into(self, out: &mut Output<Self>) {
+        out.copy_from_slice(self.hash.finish().as_slice());
+    }
+
+    fn finalize_fixed(self) -> Output<Self> {
+        let mut out = Output::<Self>::default();
+        out.copy_from_slice(self.hash.finish().as_slice());
+        out
+    }
+}
+
+#[cfg(feature = "boring")]
+impl HashMarker for BoringSha256 {}
+
+#[cfg(feature = "boring")]
+impl Default for BoringSha256 {
+    fn default() -> Self {
+        Self {
+            hash: sha::Sha256::new(),
+        }
+    }
+}
+
+/// Boring SHA-1 implementation.
+#[cfg(feature = "boring")]
+pub struct BoringSha1 {
+    hash: sha::Sha1,
+}
+
+#[cfg(feature = "boring")]
+impl Update for BoringSha1 {
+    fn update(&mut self, data: &[u8]) {
+        self.hash.update(data);
+    }
+}
+
+#[cfg(feature = "boring")]
+impl OutputSizeUser for BoringSha1 {
+    type OutputSize = U20;
+}
+
+#[cfg(feature = "boring")]
+impl FixedOutput for BoringSha1 {
+    fn finalize_into(self, out: &mut Output<Self>) {
+        out.copy_from_slice(self.hash.finish().as_slice());
+    }
+
+    fn finalize_fixed(self) -> Output<Self> {
+        let mut out = Output::<Self>::default();
+        out.copy_from_slice(self.hash.finish().as_slice());
+        out
+    }
+}
+
+#[cfg(feature = "boring")]
+impl HashMarker for BoringSha1 {}
+
+#[cfg(feature = "boring")]
+impl Default for BoringSha1 {
+    fn default() -> Self {
+        Self {
+            hash: sha::Sha1::new(),
+        }
+    }
+}

--- a/gitoid/src/boring_sha.rs
+++ b/gitoid/src/boring_sha.rs
@@ -1,29 +1,22 @@
-#[cfg(feature = "boring")]
 use boring::sha;
-#[cfg(feature = "boring")]
 use digest::{FixedOutput, HashMarker, Output, OutputSizeUser, Update};
-#[cfg(feature = "boring")]
 use digest::consts::{U20, U32};
 
 /// Boring SHA-256 implementation.
-#[cfg(feature = "boring")]
 pub struct BoringSha256 {
     hash: sha::Sha256,
 }
 
-#[cfg(feature = "boring")]
 impl Update for BoringSha256 {
     fn update(&mut self, data: &[u8]) {
         self.hash.update(data);
     }
 }
 
-#[cfg(feature = "boring")]
 impl OutputSizeUser for BoringSha256 {
     type OutputSize = U32;
 }
 
-#[cfg(feature = "boring")]
 impl FixedOutput for BoringSha256 {
     fn finalize_into(self, out: &mut Output<Self>) {
         out.copy_from_slice(self.hash.finish().as_slice());
@@ -36,10 +29,8 @@ impl FixedOutput for BoringSha256 {
     }
 }
 
-#[cfg(feature = "boring")]
 impl HashMarker for BoringSha256 {}
 
-#[cfg(feature = "boring")]
 impl Default for BoringSha256 {
     fn default() -> Self {
         Self {
@@ -49,24 +40,20 @@ impl Default for BoringSha256 {
 }
 
 /// Boring SHA-1 implementation.
-#[cfg(feature = "boring")]
 pub struct BoringSha1 {
     hash: sha::Sha1,
 }
 
-#[cfg(feature = "boring")]
 impl Update for BoringSha1 {
     fn update(&mut self, data: &[u8]) {
         self.hash.update(data);
     }
 }
 
-#[cfg(feature = "boring")]
 impl OutputSizeUser for BoringSha1 {
     type OutputSize = U20;
 }
 
-#[cfg(feature = "boring")]
 impl FixedOutput for BoringSha1 {
     fn finalize_into(self, out: &mut Output<Self>) {
         out.copy_from_slice(self.hash.finish().as_slice());
@@ -79,10 +66,8 @@ impl FixedOutput for BoringSha1 {
     }
 }
 
-#[cfg(feature = "boring")]
 impl HashMarker for BoringSha1 {}
 
-#[cfg(feature = "boring")]
 impl Default for BoringSha1 {
     fn default() -> Self {
         Self {

--- a/gitoid/src/hash_algorithm.rs
+++ b/gitoid/src/hash_algorithm.rs
@@ -101,15 +101,6 @@ pub struct Sha1Cd {
 #[cfg(feature = "sha1cd")]
 impl_hash_algorithm!(Sha1Cd, sha1collisiondetection::Sha1CD, "sha1cd");
 
-// #[cfg feature = "boring"]
-// fn boring_sha1<D: Digest>(output: &mut [u8]) {
-//     D::new();
-//     let mut hasher = boring::hash::Hasher::new(MessageDigest::sha1()).unwrap();
-//     hasher.update("hello world".as_bytes()).unwrap();
-//     let digest = hasher.finish().unwrap();
-//     output.copy_from_slice(digest.to_vec().as_slice())
-// }
-
 #[cfg(all(feature = "sha1", feature = "boring"))]
 impl_hash_algorithm!(Sha1, BoringSha1, "sha1");
 

--- a/gitoid/src/hash_algorithm.rs
+++ b/gitoid/src/hash_algorithm.rs
@@ -10,6 +10,9 @@ use digest::block_buffer::generic_array::GenericArray;
 use digest::Digest;
 use digest::OutputSizeUser;
 
+#[cfg(feature="boring")]
+use crate::boring_sha::{BoringSha1, BoringSha256};
+
 /// Hash algorithms that can be used to make a [`GitOid`].
 ///
 /// This is a sealed trait to ensure it's only used for hash
@@ -75,7 +78,7 @@ pub struct Sha1 {
     _private: (),
 }
 
-#[cfg(feature = "sha1")]
+#[cfg(all(feature = "sha1", not(feature = "boring")))]
 impl_hash_algorithm!(Sha1, sha1::Sha1, "sha1");
 
 #[cfg(feature = "sha256")]
@@ -85,7 +88,7 @@ pub struct Sha256 {
     _private: (),
 }
 
-#[cfg(feature = "sha256")]
+#[cfg(all(feature = "sha256", not(feature = "boring")))]
 impl_hash_algorithm!(Sha256, sha2::Sha256, "sha256");
 
 #[cfg(feature = "sha1cd")]
@@ -97,3 +100,18 @@ pub struct Sha1Cd {
 
 #[cfg(feature = "sha1cd")]
 impl_hash_algorithm!(Sha1Cd, sha1collisiondetection::Sha1CD, "sha1cd");
+
+// #[cfg feature = "boring"]
+// fn boring_sha1<D: Digest>(output: &mut [u8]) {
+//     D::new();
+//     let mut hasher = boring::hash::Hasher::new(MessageDigest::sha1()).unwrap();
+//     hasher.update("hello world".as_bytes()).unwrap();
+//     let digest = hasher.finish().unwrap();
+//     output.copy_from_slice(digest.to_vec().as_slice())
+// }
+
+#[cfg(all(feature = "sha1", feature = "boring"))]
+impl_hash_algorithm!(Sha1, BoringSha1, "sha1");
+
+#[cfg(all(feature = "sha256", feature = "boring"))]
+impl_hash_algorithm!(Sha256, BoringSha256, "sha256");

--- a/gitoid/src/hash_algorithm.rs
+++ b/gitoid/src/hash_algorithm.rs
@@ -10,9 +10,6 @@ use digest::block_buffer::generic_array::GenericArray;
 use digest::Digest;
 use digest::OutputSizeUser;
 
-#[cfg(feature="boring")]
-use crate::boring_sha::{BoringSha1, BoringSha256};
-
 /// Hash algorithms that can be used to make a [`GitOid`].
 ///
 /// This is a sealed trait to ensure it's only used for hash
@@ -46,6 +43,8 @@ pub trait HashAlgorithm: Sealed {
     fn new() -> Self::Alg;
 }
 
+#[doc(hidden)]
+#[macro_export]
 #[allow(unused_macros)]
 macro_rules! impl_hash_algorithm {
     ( $type:ident, $alg_ty:ty, $name:literal ) => {
@@ -70,40 +69,3 @@ macro_rules! impl_hash_algorithm {
         }
     };
 }
-
-#[cfg(feature = "sha1")]
-/// SHA-1 algorithm,
-pub struct Sha1 {
-    #[doc(hidden)]
-    _private: (),
-}
-
-#[cfg(all(feature = "sha1", feature = "rustcrypto", not(feature = "boring")))]
-impl_hash_algorithm!(Sha1, sha1::Sha1, "sha1");
-
-#[cfg(feature = "sha256")]
-/// SHA-256 algorithm.
-pub struct Sha256 {
-    #[doc(hidden)]
-    _private: (),
-}
-
-#[cfg(all(feature = "sha1cd", feature = "rustcrypto"))]
-/// SHA-1Cd (collision detection) algorithm.
-pub struct Sha1Cd {
-    #[doc(hidden)]
-    _private: (),
-}
-
-// SHA-1Cd currently has only one implementation, so we don't gate.
-#[cfg(all(feature = "sha1cd", feature="rustcrypto"))]
-impl_hash_algorithm!(Sha1Cd, sha1collisiondetection::Sha1CD, "sha1cd");
-
-#[cfg(all(feature = "sha1", feature = "boring"))]
-impl_hash_algorithm!(Sha1, BoringSha1, "sha1");
-
-#[cfg(all(feature = "sha256", feature = "rustcrypto", not(feature = "boring")))]
-impl_hash_algorithm!(Sha256, sha2::Sha256, "sha256");
-
-#[cfg(all(feature = "sha256", feature = "boring"))]
-impl_hash_algorithm!(Sha256, BoringSha256, "sha256");

--- a/gitoid/src/hash_algorithm.rs
+++ b/gitoid/src/hash_algorithm.rs
@@ -78,7 +78,7 @@ pub struct Sha1 {
     _private: (),
 }
 
-#[cfg(all(feature = "sha1", not(feature = "boring")))]
+#[cfg(all(feature = "sha1", feature = "rustcrypto", not(feature = "boring")))]
 impl_hash_algorithm!(Sha1, sha1::Sha1, "sha1");
 
 #[cfg(feature = "sha256")]
@@ -88,21 +88,22 @@ pub struct Sha256 {
     _private: (),
 }
 
-#[cfg(all(feature = "sha256", not(feature = "boring")))]
-impl_hash_algorithm!(Sha256, sha2::Sha256, "sha256");
-
-#[cfg(feature = "sha1cd")]
+#[cfg(all(feature = "sha1cd", feature = "rustcrypto"))]
 /// SHA-1Cd (collision detection) algorithm.
 pub struct Sha1Cd {
     #[doc(hidden)]
     _private: (),
 }
 
-#[cfg(feature = "sha1cd")]
+// SHA-1Cd currently has only one implementation, so we don't gate.
+#[cfg(all(feature = "sha1cd", feature="rustcrypto"))]
 impl_hash_algorithm!(Sha1Cd, sha1collisiondetection::Sha1CD, "sha1cd");
 
 #[cfg(all(feature = "sha1", feature = "boring"))]
 impl_hash_algorithm!(Sha1, BoringSha1, "sha1");
+
+#[cfg(all(feature = "sha256", feature = "rustcrypto", not(feature = "boring")))]
+impl_hash_algorithm!(Sha256, sha2::Sha256, "sha256");
 
 #[cfg(all(feature = "sha256", feature = "boring"))]
 impl_hash_algorithm!(Sha256, BoringSha256, "sha256");

--- a/gitoid/src/lib.rs
+++ b/gitoid/src/lib.rs
@@ -119,6 +119,8 @@ mod object_type;
 
 #[cfg(test)]
 mod tests;
+#[cfg(feature = "boring")]
+mod boring_sha;
 
 pub(crate) use crate::error::Result;
 

--- a/gitoid/src/lib.rs
+++ b/gitoid/src/lib.rs
@@ -105,43 +105,47 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(any(feature = "sha1", feature = "sha1cd", feature = "sha256", feature = "rustcrypto")))]
+#[cfg(not(any(
+    feature = "sha1",
+    feature = "sha1cd",
+    feature = "sha256",
+    feature = "rustcrypto"
+)))]
 compile_error!(
     r#"At least one hash algorithm feature must be active: "sha1", "sha1cd", or "sha256""#
 );
 
-#[cfg(all(feature = "sha1cd", feature = "boring", not(feature = "rustcrypto")))]
-compile_error!("The 'boring' feature does not support the 'sha1cd' algorithm. Please enable the 'rustcrypto' feature.");
+#[cfg(all(feature = "sha1cd", feature = "boringssl", not(feature = "rustcrypto")))]
+compile_error!(r#"The "boringssl" feature does not support the "sha1cd" algorithm"#);
 
-#[cfg(all(feature = "rustcrypto", not(any(feature = "sha1", feature = "sha1cd", feature = "sha256"))))]
-compile_error!("The 'rustcrypto' feature requires at least one of the following algorithms: 'sha1', 'sha1cd', or 'sha256'.");
+#[cfg(all(
+    feature = "rustcrypto",
+    not(any(feature = "sha1", feature = "sha1cd", feature = "sha256"))
+))]
+compile_error!(
+    r#"The "rustcrypto" feature requires at least one of the following algorithms: "sha1", "sha1cd", or "sha256""#
+);
 
-#[cfg(not(any(feature = "rustcrypto", feature = "boring")))]
-compile_error!("At least one of the 'rustcrypto' or 'boring' features must be enabled.");
+#[cfg(not(any(feature = "rustcrypto", feature = "boringssl")))]
+compile_error!(r#"At least one of the "rustcrypto" or "boringssl" features must be enabled"#);
 
-pub(crate) mod sealed;
-
+mod backend;
 mod error;
 mod gitoid;
 mod hash_algorithm;
 mod object_type;
-
+pub(crate) mod sealed;
 #[cfg(test)]
 mod tests;
-#[cfg(feature = "boring")]
-mod boring_sha;
 
-pub(crate) use crate::error::Result;
-
+#[cfg(feature = "boringssl")]
+pub use crate::backend::boringssl;
+#[cfg(feature = "rustcrypto")]
+pub use crate::backend::rustcrypto;
 pub use crate::error::Error;
+pub(crate) use crate::error::Result;
 pub use crate::gitoid::GitOid;
 pub use crate::hash_algorithm::HashAlgorithm;
-#[cfg(feature = "sha1")]
-pub use crate::hash_algorithm::Sha1;
-#[cfg(feature = "sha1cd")]
-pub use crate::hash_algorithm::Sha1Cd;
-#[cfg(feature = "sha256")]
-pub use crate::hash_algorithm::Sha256;
 pub use crate::object_type::Blob;
 pub use crate::object_type::Commit;
 pub use crate::object_type::ObjectType;

--- a/gitoid/src/lib.rs
+++ b/gitoid/src/lib.rs
@@ -105,10 +105,19 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(any(feature = "sha1", feature = "sha1cd", feature = "sha256")))]
+#[cfg(not(any(feature = "sha1", feature = "sha1cd", feature = "sha256", feature = "rustcrypto")))]
 compile_error!(
     r#"At least one hash algorithm feature must be active: "sha1", "sha1cd", or "sha256""#
 );
+
+#[cfg(all(feature = "sha1cd", feature = "boring", not(feature = "rustcrypto")))]
+compile_error!("The 'boring' feature does not support the 'sha1cd' algorithm. Please enable the 'rustcrypto' feature.");
+
+#[cfg(all(feature = "rustcrypto", not(any(feature = "sha1", feature = "sha1cd", feature = "sha256"))))]
+compile_error!("The 'rustcrypto' feature requires at least one of the following algorithms: 'sha1', 'sha1cd', or 'sha256'.");
+
+#[cfg(not(any(feature = "rustcrypto", feature = "boring")))]
+compile_error!("At least one of the 'rustcrypto' or 'boring' features must be enabled.");
 
 pub(crate) mod sealed;
 

--- a/gitoid/src/tests.rs
+++ b/gitoid/src/tests.rs
@@ -1,6 +1,10 @@
 #![allow(unused_imports)]
 
 use super::*;
+#[cfg(all(feature = "sha1", feature = "rustcrypto"))]
+use crate::rustcrypto::Sha1;
+#[cfg(all(feature = "sha256", feature = "rustcrypto"))]
+use crate::rustcrypto::Sha256;
 #[cfg(feature = "std")]
 use std::fs::File;
 #[cfg(feature = "async")]
@@ -16,10 +20,7 @@ use {
     serde_test::{assert_tokens, Token},
 };
 
-#[cfg(feature = "sha256")]
-use crate::Sha256;
-
-#[cfg(all(feature = "sha1", feature = "hex"))]
+#[cfg(all(feature = "sha1", feature = "rustcrypto", feature = "hex"))]
 #[test]
 fn generate_sha1_gitoid_from_bytes() {
     let input = b"hello world";
@@ -33,7 +34,7 @@ fn generate_sha1_gitoid_from_bytes() {
     );
 }
 
-#[cfg(all(feature = "sha1", feature = "std"))]
+#[cfg(all(feature = "sha1", feature = "rustcrypto", feature = "std"))]
 #[test]
 fn generate_sha1_gitoid_from_buffer() -> Result<()> {
     let reader = File::open("test/data/hello_world.txt")?;
@@ -49,7 +50,7 @@ fn generate_sha1_gitoid_from_buffer() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "sha256")]
+#[cfg(all(feature = "sha256", feature = "rustcrypto"))]
 #[test]
 fn generate_sha256_gitoid_from_bytes() {
     let input = b"hello world";
@@ -66,7 +67,7 @@ fn generate_sha256_gitoid_from_bytes() {
     );
 }
 
-#[cfg(all(feature = "sha256", feature = "std"))]
+#[cfg(all(feature = "sha256", feature = "rustcrypto", feature = "std"))]
 #[test]
 fn generate_sha256_gitoid_from_buffer() -> Result<()> {
     let reader = File::open("test/data/hello_world.txt")?;
@@ -85,7 +86,7 @@ fn generate_sha256_gitoid_from_buffer() -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(feature = "sha256", feature = "async"))]
+#[cfg(all(feature = "sha256", feature = "rustcrypto", feature = "async"))]
 #[test]
 fn generate_sha256_gitoid_from_async_buffer() -> Result<()> {
     let runtime = Runtime::new()?;
@@ -107,7 +108,7 @@ fn generate_sha256_gitoid_from_async_buffer() -> Result<()> {
     })
 }
 
-#[cfg(feature = "sha256")]
+#[cfg(all(feature = "sha256", feature = "rustcrypto"))]
 #[test]
 fn validate_uri() -> Result<()> {
     let content = b"hello world";
@@ -121,7 +122,7 @@ fn validate_uri() -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(feature = "sha256", feature = "url"))]
+#[cfg(all(feature = "sha256", feature = "rustcrypto", feature = "url"))]
 #[test]
 fn try_from_url_bad_scheme() {
     let url = Url::parse(
@@ -135,7 +136,7 @@ fn try_from_url_bad_scheme() {
     }
 }
 
-#[cfg(all(feature = "sha1", feature = "url"))]
+#[cfg(all(feature = "sha1", feature = "rustcrypto", feature = "url"))]
 #[test]
 fn try_from_url_missing_object_type() {
     let url = Url::parse("gitoid:").unwrap();
@@ -146,7 +147,7 @@ fn try_from_url_missing_object_type() {
     }
 }
 
-#[cfg(all(feature = "sha1", feature = "url"))]
+#[cfg(all(feature = "sha1", feature = "rustcrypto", feature = "url"))]
 #[test]
 fn try_from_url_bad_object_type() {
     let url = Url::parse("gitoid:whatever").unwrap();
@@ -157,7 +158,7 @@ fn try_from_url_bad_object_type() {
     }
 }
 
-#[cfg(all(feature = "sha256", feature = "url"))]
+#[cfg(all(feature = "sha256", feature = "rustcrypto", feature = "url"))]
 #[test]
 fn try_from_url_missing_hash_algorithm() {
     let url = Url::parse("gitoid:blob:").unwrap();
@@ -171,7 +172,7 @@ fn try_from_url_missing_hash_algorithm() {
     }
 }
 
-#[cfg(all(feature = "sha1", feature = "url"))]
+#[cfg(all(feature = "sha1", feature = "rustcrypto", feature = "url"))]
 #[test]
 fn try_from_url_bad_hash_algorithm() {
     let url = Url::parse("gitoid:blob:sha10000").unwrap();
@@ -182,7 +183,7 @@ fn try_from_url_bad_hash_algorithm() {
     }
 }
 
-#[cfg(all(feature = "sha256", feature = "url"))]
+#[cfg(all(feature = "sha256", feature = "rustcrypto", feature = "url"))]
 #[test]
 fn try_from_url_missing_hash() {
     let url = Url::parse("gitoid:blob:sha256:").unwrap();
@@ -193,7 +194,7 @@ fn try_from_url_missing_hash() {
     }
 }
 
-#[cfg(all(feature = "sha256", feature = "url"))]
+#[cfg(all(feature = "sha256", feature = "rustcrypto", feature = "url"))]
 #[test]
 fn try_url_roundtrip() {
     let url = Url::parse(
@@ -205,7 +206,7 @@ fn try_url_roundtrip() {
     assert_eq!(url, output);
 }
 
-#[cfg(all(feature = "serde", feature = "sha256"))]
+#[cfg(all(feature = "serde", feature = "sha256", feature = "rustcrypto"))]
 #[test]
 fn valid_gitoid_ser_de() {
     let id = GitOid::<Sha256, Blob>::id_str("hello, world");

--- a/gitoid/src/tests.rs
+++ b/gitoid/src/tests.rs
@@ -13,9 +13,11 @@ use url::Url;
 use {
     crate::Blob,
     crate::GitOid,
-    crate::Sha256,
     serde_test::{assert_tokens, Token},
 };
+
+#[cfg(feature = "sha256")]
+use crate::Sha256;
 
 #[cfg(all(feature = "sha1", feature = "hex"))]
 #[test]
@@ -203,7 +205,7 @@ fn try_url_roundtrip() {
     assert_eq!(url, output);
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "sha256"))]
 #[test]
 fn valid_gitoid_ser_de() {
     let id = GitOid::<Sha256, Blob>::id_str("hello, world");


### PR DESCRIPTION
This commit introduces support for the BoringSSL backend for SHA-1 and
SHA-256 in the gitoid Rust package. The SHA-1CD algorithm is not
supported with this backend. To enable BoringSSL, use the "boring"
feature in Cargo.

Additionally, benchmarks have been added to measure the performance
of the implemented cryptographic algorithms.

Signed-off-by: Frederick F. Kautz IV <fkautz@alumni.cmu.edu>
