### PR TITLE
chore: Add comments, fixup conditional compilations

### DIFF
--- a/gitoid/Cargo.toml
+++ b/gitoid/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "1.0.197", optional = true }
 tokio = { version = "1.36.0", features = ["io-util"], optional = true }
 url = { version = "2.4.1", optional = true }
 boring = { version = "4.6.0", optional = true }
-openssl = {version = "0.10.66", optional = true }
+openssl = { version = "0.10.66", optional = true }
 
 [dev-dependencies]
 
@@ -126,6 +126,13 @@ rustcrypto = []
 # implementations out. Since they're _always_ present, we might as well
 # use them unconditionally.
 boringssl = ["dep:boring", "sha1", "sha256"]
+
+# Enable using OpenSSL as a cryptography backend.
+#
+# NOTE: Like the "boringssl" feature, this unconditionally turns on
+# the "sha1" and "sha256" features, as they're not able to be
+# conditionally compiled out of the dependency, so there's no reason to omit
+# them here.
 openssl = ["dep:openssl", "sha1", "sha256"]
 
 [[bench]]

--- a/gitoid/src/gitoid.rs
+++ b/gitoid/src/gitoid.rs
@@ -14,7 +14,9 @@ use core::hash::Hash;
 use core::hash::Hasher;
 use core::marker::PhantomData;
 use core::ops::Not as _;
+#[cfg(feature = "serde")]
 use core::result::Result as StdResult;
+#[cfg(feature = "url")]
 use core::str::FromStr;
 #[cfg(feature = "url")]
 use core::str::Split;
@@ -165,6 +167,7 @@ where
     }
 }
 
+#[cfg(feature = "url")]
 impl<H, O> FromStr for GitOid<H, O>
 where
     H: HashAlgorithm,

--- a/gitoid/src/lib.rs
+++ b/gitoid/src/lib.rs
@@ -105,12 +105,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(any(
-    feature = "sha1",
-    feature = "sha1cd",
-    feature = "sha256",
-    feature = "rustcrypto",
-)))]
+#[cfg(not(any(feature = "sha1", feature = "sha1cd", feature = "sha256")))]
 compile_error!(
     r#"At least one hash algorithm feature must be active: "sha1", "sha1cd", or "sha256""#
 );
@@ -130,7 +125,9 @@ compile_error!(
 );
 
 #[cfg(not(any(feature = "rustcrypto", feature = "boringssl", feature = "openssl")))]
-compile_error!(r#"At least one of the "rustcrypto", "boringssl", or "openssl" features must be enabled"#);
+compile_error!(
+    r#"At least one of the "rustcrypto", "boringssl", or "openssl" features must be enabled"#
+);
 
 mod backend;
 mod error;
@@ -143,10 +140,10 @@ mod tests;
 
 #[cfg(feature = "boringssl")]
 pub use crate::backend::boringssl;
-#[cfg(feature = "rustcrypto")]
-pub use crate::backend::rustcrypto;
 #[cfg(feature = "openssl")]
 pub use crate::backend::openssl;
+#[cfg(feature = "rustcrypto")]
+pub use crate::backend::rustcrypto;
 pub use crate::error::Error;
 pub(crate) use crate::error::Result;
 pub use crate::gitoid::GitOid;


### PR DESCRIPTION
This commit includes some minor formatting fixes, addition of comments to
the Cargo.toml for the gitoid crate, and adjustment of some conditional
compilations to ensure that we can still compile in some specific
combinations of features which were accidentally made failing by some
prior changes.
