### PR TITLE
feat: Introduce PrintSender type

### DIFF
--- a/omnibor-cli/src/cmd/artifact/id.rs
+++ b/omnibor-cli/src/cmd/artifact/id.rs
@@ -4,12 +4,11 @@ use crate::{
     cli::{Config, IdArgs},
     error::Result,
     fs::*,
-    print::PrinterCmd,
+    print::PrintSender,
 };
-use tokio::sync::mpsc::Sender;
 
 /// Run the `artifact id` subcommand.
-pub async fn run(tx: &Sender<PrinterCmd>, config: &Config, args: &IdArgs) -> Result<()> {
+pub async fn run(tx: &PrintSender, config: &Config, args: &IdArgs) -> Result<()> {
     let mut file = open_async_file(&args.path).await?;
 
     if file_is_dir(&file, &args.path).await? {

--- a/omnibor-cli/src/cmd/debug/config.rs
+++ b/omnibor-cli/src/cmd/debug/config.rs
@@ -3,17 +3,15 @@
 use crate::{
     cli::Config,
     error::{Error, Result},
-    print::{root_dir::RootDirMsg, PrinterCmd},
+    print::{root_dir::RootDirMsg, PrintSender, PrinterCmd},
 };
-use tokio::sync::mpsc::Sender;
 
 /// Run the `debug config` subcommand.
-pub async fn run(tx: &Sender<PrinterCmd>, config: &Config) -> Result<()> {
+pub async fn run(tx: &PrintSender, config: &Config) -> Result<()> {
     let root = config.dir().ok_or(Error::NoRoot)?.to_path_buf();
 
     tx.send(PrinterCmd::msg(RootDirMsg { path: root }, config.format()))
-        .await
-        .map_err(|_| Error::PrintChannelClose)?;
+        .await?;
 
     Ok(())
 }

--- a/omnibor-cli/src/cmd/manifest/add.rs
+++ b/omnibor-cli/src/cmd/manifest/add.rs
@@ -3,15 +3,10 @@
 use crate::{
     cli::{Config, ManifestAddArgs},
     error::Result,
-    print::PrinterCmd,
+    print::PrintSender,
 };
-use tokio::sync::mpsc::Sender;
 
 /// Run the `manifest add` subcommand.
-pub async fn run(
-    _tx: &Sender<PrinterCmd>,
-    _config: &Config,
-    _args: &ManifestAddArgs,
-) -> Result<()> {
+pub async fn run(_tx: &PrintSender, _config: &Config, _args: &ManifestAddArgs) -> Result<()> {
     todo!()
 }

--- a/omnibor-cli/src/cmd/manifest/create.rs
+++ b/omnibor-cli/src/cmd/manifest/create.rs
@@ -3,21 +3,16 @@
 use crate::{
     cli::{Config, ManifestCreateArgs},
     error::{Error, Result},
-    print::PrinterCmd,
+    print::PrintSender,
 };
 use omnibor::{
     embedding::NoEmbed, hashes::Sha256, storage::FileSystemStorage, InputManifestBuilder,
     IntoArtifactId, RelationKind,
 };
-use tokio::sync::mpsc::Sender;
 use tracing::info;
 
 /// Run the `manifest create` subcommand.
-pub async fn run(
-    _tx: &Sender<PrinterCmd>,
-    config: &Config,
-    args: &ManifestCreateArgs,
-) -> Result<()> {
+pub async fn run(_tx: &PrintSender, config: &Config, args: &ManifestCreateArgs) -> Result<()> {
     let root = config.dir().ok_or_else(|| Error::NoRoot)?;
 
     info!(root = %root.display());

--- a/omnibor-cli/src/cmd/manifest/remove.rs
+++ b/omnibor-cli/src/cmd/manifest/remove.rs
@@ -3,15 +3,10 @@
 use crate::{
     cli::{Config, ManifestRemoveArgs},
     error::Result,
-    print::PrinterCmd,
+    print::PrintSender,
 };
-use tokio::sync::mpsc::Sender;
 
 /// Run the `manifest remove` subcommand.
-pub async fn run(
-    _tx: &Sender<PrinterCmd>,
-    _config: &Config,
-    _args: &ManifestRemoveArgs,
-) -> Result<()> {
+pub async fn run(_tx: &PrintSender, _config: &Config, _args: &ManifestRemoveArgs) -> Result<()> {
     todo!()
 }


### PR DESCRIPTION
Wrap the underlying Tokio sender so we can do our own error type on it. This updates all callers to only use the new wrapper type.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
