### PR TITLE
feat: Added snapshot tests for `omnibor artifact id`

### DIFF
--- a/omnibor-cli/tests/data/main.c
+++ b/omnibor-cli/tests/data/main.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello, world!\n");
+}

--- a/omnibor-cli/tests/snapshots/test__artifact_id_json.snap
+++ b/omnibor-cli/tests/snapshots/test__artifact_id_json.snap
@@ -1,0 +1,18 @@
+---
+source: omnibor-cli/tests/test.rs
+info:
+  program: omnibor
+  args:
+    - artifact
+    - id
+    - "--format"
+    - json
+    - "--path"
+    - tests/data/main.c
+---
+success: true
+exit_code: 0
+----- stdout -----
+{"id":"<GITOID>","path":"tests/data/main.c"}
+
+----- stderr -----

--- a/omnibor-cli/tests/snapshots/test__artifact_id_plain.snap
+++ b/omnibor-cli/tests/snapshots/test__artifact_id_plain.snap
@@ -1,0 +1,18 @@
+---
+source: omnibor-cli/tests/test.rs
+info:
+  program: omnibor
+  args:
+    - artifact
+    - id
+    - "--format"
+    - plain
+    - "--path"
+    - tests/data/main.c
+---
+success: true
+exit_code: 0
+----- stdout -----
+tests/data/main.c => <GITOID>
+
+----- stderr -----

--- a/omnibor-cli/tests/snapshots/test__artifact_id_short.snap
+++ b/omnibor-cli/tests/snapshots/test__artifact_id_short.snap
@@ -1,0 +1,18 @@
+---
+source: omnibor-cli/tests/test.rs
+info:
+  program: omnibor
+  args:
+    - artifact
+    - id
+    - "--format"
+    - short
+    - "--path"
+    - tests/data/main.c
+---
+success: true
+exit_code: 0
+----- stdout -----
+<GITOID>
+
+----- stderr -----

--- a/omnibor-cli/tests/test.rs
+++ b/omnibor-cli/tests/test.rs
@@ -6,6 +6,7 @@ macro_rules! settings {
     ($block:expr) => {
         let mut settings = Settings::clone_current();
         settings.add_filter(r#"omnibor(?:\.exe)?"#, "omnibor");
+        settings.add_filter(r#"gitoid:blob:sha256:[a-f0-9]{64}"#, "<GITOID>");
         settings.bind(|| $block);
     };
 }
@@ -35,5 +36,47 @@ fn manifest_no_args() {
 fn debug_no_args() {
     settings!({
         assert_cmd_snapshot!(Command::new(get_cargo_bin("omnibor")).arg("debug"));
+    });
+}
+
+#[test]
+fn artifact_id_plain() {
+    settings!({
+        assert_cmd_snapshot!(Command::new(get_cargo_bin("omnibor")).args([
+            "artifact",
+            "id",
+            "--format",
+            "plain",
+            "--path",
+            "tests/data/main.c"
+        ]))
+    });
+}
+
+#[test]
+fn artifact_id_short() {
+    settings!({
+        assert_cmd_snapshot!(Command::new(get_cargo_bin("omnibor")).args([
+            "artifact",
+            "id",
+            "--format",
+            "short",
+            "--path",
+            "tests/data/main.c"
+        ]))
+    });
+}
+
+#[test]
+fn artifact_id_json() {
+    settings!({
+        assert_cmd_snapshot!(Command::new(get_cargo_bin("omnibor")).args([
+            "artifact",
+            "id",
+            "--format",
+            "json",
+            "--path",
+            "tests/data/main.c"
+        ]))
     });
 }


### PR DESCRIPTION
This adds snapshot tests for all three formats of the `omnibor artifact id` subcommand, to catch formatting regressions in the future.