### PR TITLE
feat: Identify files in parallel.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
 
 [alias]
 xtask = "run --package xtask --"
+
+[build]
+# Needed for using `tokio_console` with the CLI.
+rustflags = ["--cfg", "tokio_unstable"]

--- a/omnibor-cli/Cargo.toml
+++ b/omnibor-cli/Cargo.toml
@@ -26,14 +26,22 @@ default-run = "omnibor"
 name = "omnibor"
 path = "src/main.rs"
 
+[features]
+
+# Optionally turn on `tokio-console` support.
+console = ["dep:console-subscriber"]
+
 [dependencies]
+async-channel = "2.3.1"
 
 async-walkdir = "1.0.0"
 clap = { version = "4.5.1", features = ["derive", "env"] }
 clap-verbosity-flag = "2.2.2"
+console-subscriber = { version = "0.4.1", optional = true }
 dirs = "5.0.1"
 dyn-clone = "1.0.17"
 futures-lite = "2.2.0"
+futures-util = "0.3.31"
 omnibor = { version = "0.6.0", path = "../omnibor" }
 pathbuf = "1.0.0"
 serde_json = "1.0.114"
@@ -47,6 +55,7 @@ tokio = { version = "1.36.0", features = [
     "rt-multi-thread",
     "sync",
     "time",
+    "tracing",
 ] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/omnibor-cli/src/error.rs
+++ b/omnibor-cli/src/error.rs
@@ -1,7 +1,9 @@
 //! Error types.
 
+use async_channel::SendError;
 use omnibor::Error as OmniborError;
 use std::{io::Error as IoError, path::PathBuf, result::Result as StdResult};
+use tokio::task::JoinError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -59,6 +61,12 @@ pub enum Error {
         #[source]
         source: OmniborError,
     },
+
+    #[error("work channel closed for sending")]
+    WorkChannelCloseSend(#[source] SendError<PathBuf>),
+
+    #[error("failed to join worker task")]
+    CouldNotJoinWorker(#[source] JoinError),
 
     #[error("print channel closed")]
     PrintChannelClose,


### PR DESCRIPTION
Update the ID logic to work in parallel, with a "walk task" that walks the directory structure, and a dynamic set of "worker tasks" that consume the paths produced by the walk task and ID each path.

This uses `async-channel` for its consume-once semantics.