### PR TITLE
chore: Remove "buffer" tunable.

### DIFF
--- a/omnibor-cli/src/cli.rs
+++ b/omnibor-cli/src/cli.rs
@@ -27,17 +27,6 @@ static DEFAULT_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
     subcommand_required = true
 )]
 pub struct Config {
-    /// How many print messages to buffer at once
-    #[arg(
-        short = 'b',
-        long = "buffer",
-        default_value = "100",
-        global = true,
-        env = "OMNIBOR_BUFFER",
-        help_heading = "General Flags"
-    )]
-    buffer: Option<usize>,
-
     /// Output format
     #[arg(
         short = 'f',
@@ -76,11 +65,6 @@ pub struct Config {
 }
 
 impl Config {
-    /// Get the configured buffer size.
-    pub fn buffer(&self) -> usize {
-        self.buffer.unwrap()
-    }
-
     /// Get the selected format.
     pub fn format(&self) -> Format {
         self.format.unwrap_or_default()

--- a/omnibor-cli/src/main.rs
+++ b/omnibor-cli/src/main.rs
@@ -31,7 +31,8 @@ fn main() -> ExitCode {
 async fn run() -> ExitCode {
     let config = Config::parse();
     init_log(&config.verbose);
-    let printer = Printer::launch(config.buffer());
+    // TODO: Make this tunable.
+    let printer = Printer::launch(100);
     trace!(config = ?config);
 
     match run_cmd(printer.tx(), &config).await {

--- a/omnibor-cli/tests/snapshots/test__artifact_no_args.snap
+++ b/omnibor-cli/tests/snapshots/test__artifact_no_args.snap
@@ -26,7 +26,6 @@ Options:
   -V, --version     Print version
 
 General Flags:
-  -b, --buffer <BUFFER>  How many print messages to buffer at once [env: OMNIBOR_BUFFER=] [default: 100]
   -f, --format <FORMAT>  Output format [env: OMNIBOR_FORMAT=] [possible values: plain, json, short]
   -H, --hash <HASH>      Hash algorithm to use when parsing Artifact IDs [env: OMNIBOR_HASH=] [possible values: sha256]
   -d, --dir <DIR>        Directory to store manifests [env: OMNIBOR_DIR=]

--- a/omnibor-cli/tests/snapshots/test__debug_no_args.snap
+++ b/omnibor-cli/tests/snapshots/test__debug_no_args.snap
@@ -25,7 +25,6 @@ Options:
   -V, --version     Print version
 
 General Flags:
-  -b, --buffer <BUFFER>  How many print messages to buffer at once [env: OMNIBOR_BUFFER=] [default: 100]
   -f, --format <FORMAT>  Output format [env: OMNIBOR_FORMAT=] [possible values: plain, json, short]
   -H, --hash <HASH>      Hash algorithm to use when parsing Artifact IDs [env: OMNIBOR_HASH=] [possible values: sha256]
   -d, --dir <DIR>        Directory to store manifests [env: OMNIBOR_DIR=]

--- a/omnibor-cli/tests/snapshots/test__manifest_no_args.snap
+++ b/omnibor-cli/tests/snapshots/test__manifest_no_args.snap
@@ -27,7 +27,6 @@ Options:
   -V, --version     Print version
 
 General Flags:
-  -b, --buffer <BUFFER>  How many print messages to buffer at once [env: OMNIBOR_BUFFER=] [default: 100]
   -f, --format <FORMAT>  Output format [env: OMNIBOR_FORMAT=] [possible values: plain, json, short]
   -H, --hash <HASH>      Hash algorithm to use when parsing Artifact IDs [env: OMNIBOR_HASH=] [possible values: sha256]
   -d, --dir <DIR>        Directory to store manifests [env: OMNIBOR_DIR=]

--- a/omnibor-cli/tests/snapshots/test__no_args.snap
+++ b/omnibor-cli/tests/snapshots/test__no_args.snap
@@ -26,7 +26,6 @@ Options:
   -V, --version     Print version
 
 General Flags:
-  -b, --buffer <BUFFER>  How many print messages to buffer at once [env: OMNIBOR_BUFFER=] [default: 100]
   -f, --format <FORMAT>  Output format [env: OMNIBOR_FORMAT=] [possible values: plain, json, short]
   -H, --hash <HASH>      Hash algorithm to use when parsing Artifact IDs [env: OMNIBOR_HASH=] [possible values: sha256]
   -d, --dir <DIR>        Directory to store manifests [env: OMNIBOR_DIR=]


### PR DESCRIPTION
I have a more general plan for handling performance tunables that doesn't involve adding a bunch of one-off command line flags.