### PR TITLE
feat: Introduce config for tunables

### DIFF
--- a/omnibor-cli/Cargo.toml
+++ b/omnibor-cli/Cargo.toml
@@ -26,24 +26,20 @@ default-run = "omnibor"
 name = "omnibor"
 path = "src/main.rs"
 
-[features]
-
-# Optionally turn on `tokio-console` support.
-console = ["dep:console-subscriber"]
-
 [dependencies]
 async-channel = "2.3.1"
 
 async-walkdir = "1.0.0"
 clap = { version = "4.5.1", features = ["derive", "env"] }
 clap-verbosity-flag = "2.2.2"
-console-subscriber = { version = "0.4.1", optional = true }
+console-subscriber = "0.4.1"
 dirs = "5.0.1"
 dyn-clone = "1.0.17"
 futures-lite = "2.2.0"
 futures-util = "0.3.31"
 omnibor = { version = "0.6.0", path = "../omnibor" }
 pathbuf = "1.0.0"
+serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.114"
 thiserror = "2.0.3"
 tokio = { version = "1.36.0", features = [

--- a/omnibor-cli/config/omnibor.json
+++ b/omnibor-cli/config/omnibor.json
@@ -1,0 +1,7 @@
+{
+  "perf": {
+    "print_queue_size": 1,
+    "work_queue_size": 1,
+    "num_workers": 1
+  }
+}

--- a/omnibor-cli/src/app.rs
+++ b/omnibor-cli/src/app.rs
@@ -1,0 +1,10 @@
+use crate::{cli::Args, config::Config};
+
+#[derive(Debug)]
+pub struct App {
+    /// The user's command line arguments.
+    pub args: Args,
+
+    /// Configuration data.
+    pub config: Config,
+}

--- a/omnibor-cli/src/cmd/artifact/id.rs
+++ b/omnibor-cli/src/cmd/artifact/id.rs
@@ -1,20 +1,22 @@
 //! The `artifact id` command, which identifies files.
 
-use crate::{
-    cli::{Config, IdArgs},
-    error::Result,
-    fs::*,
-    print::PrintSender,
-};
+use crate::{app::App, cli::IdArgs, error::Result, fs::*, print::PrintSender};
 
 /// Run the `artifact id` subcommand.
-pub async fn run(tx: &PrintSender, config: &Config, args: &IdArgs) -> Result<()> {
+pub async fn run(tx: &PrintSender, app: &App, args: &IdArgs) -> Result<()> {
     let mut file = open_async_file(&args.path).await?;
 
     if file_is_dir(&file, &args.path).await? {
-        id_directory(tx, &args.path, config.format(), config.hash()).await?;
+        id_directory(app, tx, &args.path).await?;
     } else {
-        id_file(tx, &mut file, &args.path, config.format(), config.hash()).await?;
+        id_file(
+            tx,
+            &mut file,
+            &args.path,
+            app.args.format(),
+            app.args.hash(),
+        )
+        .await?;
     }
 
     Ok(())

--- a/omnibor-cli/src/cmd/debug/config.rs
+++ b/omnibor-cli/src/cmd/debug/config.rs
@@ -1,17 +1,20 @@
 //! The `debug config` command, which helps debug the CLI configuration.
 
 use crate::{
-    cli::Config,
+    app::App,
     error::{Error, Result},
     print::{root_dir::RootDirMsg, PrintSender, PrinterCmd},
 };
 
 /// Run the `debug config` subcommand.
-pub async fn run(tx: &PrintSender, config: &Config) -> Result<()> {
-    let root = config.dir().ok_or(Error::NoRoot)?.to_path_buf();
+pub async fn run(tx: &PrintSender, app: &App) -> Result<()> {
+    let root = app.args.dir().ok_or(Error::NoRoot)?.to_path_buf();
 
-    tx.send(PrinterCmd::msg(RootDirMsg { path: root }, config.format()))
-        .await?;
+    tx.send(PrinterCmd::msg(
+        RootDirMsg { path: root },
+        app.args.format(),
+    ))
+    .await?;
 
     Ok(())
 }

--- a/omnibor-cli/src/cmd/manifest/add.rs
+++ b/omnibor-cli/src/cmd/manifest/add.rs
@@ -1,12 +1,8 @@
 //! The `manifest add` command, which adds manifests.
 
-use crate::{
-    cli::{Config, ManifestAddArgs},
-    error::Result,
-    print::PrintSender,
-};
+use crate::{app::App, cli::ManifestAddArgs, error::Result, print::PrintSender};
 
 /// Run the `manifest add` subcommand.
-pub async fn run(_tx: &PrintSender, _config: &Config, _args: &ManifestAddArgs) -> Result<()> {
+pub async fn run(_tx: &PrintSender, _app: &App, _args: &ManifestAddArgs) -> Result<()> {
     todo!()
 }

--- a/omnibor-cli/src/cmd/manifest/create.rs
+++ b/omnibor-cli/src/cmd/manifest/create.rs
@@ -1,7 +1,8 @@
 //! The `manifest create` command, which creates manifests.
 
 use crate::{
-    cli::{Config, ManifestCreateArgs},
+    app::App,
+    cli::ManifestCreateArgs,
     error::{Error, Result},
     print::PrintSender,
 };
@@ -12,8 +13,8 @@ use omnibor::{
 use tracing::info;
 
 /// Run the `manifest create` subcommand.
-pub async fn run(_tx: &PrintSender, config: &Config, args: &ManifestCreateArgs) -> Result<()> {
-    let root = config.dir().ok_or_else(|| Error::NoRoot)?;
+pub async fn run(_tx: &PrintSender, app: &App, args: &ManifestCreateArgs) -> Result<()> {
+    let root = app.args.dir().ok_or_else(|| Error::NoRoot)?;
 
     info!(root = %root.display());
 

--- a/omnibor-cli/src/cmd/manifest/remove.rs
+++ b/omnibor-cli/src/cmd/manifest/remove.rs
@@ -1,12 +1,8 @@
 //! The `manifest remove` command, which removes manifests.
 
-use crate::{
-    cli::{Config, ManifestRemoveArgs},
-    error::Result,
-    print::PrintSender,
-};
+use crate::{app::App, cli::ManifestRemoveArgs, error::Result, print::PrintSender};
 
 /// Run the `manifest remove` subcommand.
-pub async fn run(_tx: &PrintSender, _config: &Config, _args: &ManifestRemoveArgs) -> Result<()> {
+pub async fn run(_tx: &PrintSender, _app: &App, _args: &ManifestRemoveArgs) -> Result<()> {
     todo!()
 }

--- a/omnibor-cli/src/config.rs
+++ b/omnibor-cli/src/config.rs
@@ -1,0 +1,132 @@
+use crate::{
+    cli::DEFAULT_CONFIG,
+    error::{Error, Result},
+};
+use serde::Deserialize;
+use std::{fs::File, path::Path};
+use tokio::runtime::Handle;
+use tracing::debug;
+
+#[derive(Debug, Default, Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub perf: PerfConfig,
+}
+
+impl Config {
+    pub fn init(path: Option<&Path>) -> Result<Self> {
+        let Some(path) = path else {
+            debug!("no config path provided");
+            return Ok(Config::default());
+        };
+
+        let file = match File::open(path) {
+            Ok(file) => file,
+            Err(error) => {
+                // If we simply didn't find the default file, that's fine. It's
+                // allowed to be missing, we just use the default config.
+                if file_was_not_found(&error) && is_default_path(path) {
+                    return Ok(Config::default());
+                }
+
+                match (file_was_not_found(&error), is_default_path(path)) {
+                    // Not found, is default.
+                    (true, true) => return Ok(Config::default()),
+                    // Not found, is not default.
+                    (true, false) => {
+                        return Err(Error::ConfigNotFound {
+                            path: path.to_path_buf(),
+                            source: error,
+                        });
+                    }
+                    // Found, is default.
+                    (false, true) => {
+                        return Err(Error::ConfigDefaultCouldNotRead {
+                            path: path.to_path_buf(),
+                            source: error,
+                        })
+                    }
+                    // Found, is not default.
+                    (false, false) => {
+                        return Err(Error::ConfigCouldNotRead {
+                            path: path.to_path_buf(),
+                            source: error,
+                        })
+                    }
+                }
+            }
+        };
+
+        let config = serde_json::from_reader(file).map_err(Error::CantReadConfig)?;
+        Ok(config)
+    }
+}
+
+fn file_was_not_found(error: &std::io::Error) -> bool {
+    matches!(error.kind(), std::io::ErrorKind::NotFound)
+}
+
+fn is_default_path(path: &Path) -> bool {
+    let Some(Some(default_path)) = DEFAULT_CONFIG.get() else {
+        return false;
+    };
+
+    path == default_path
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct PerfConfig {
+    /// The max number of print items that can be held in the print queue.
+    print_queue_size: PrintQueueSize,
+
+    /// The max number of work items that can be held in the work queue.
+    work_queue_size: WorkQueueSize,
+
+    /// The number of worker tasks to spawn.
+    num_workers: NumWorkers,
+}
+
+impl PerfConfig {
+    pub fn print_queue_size(&self) -> usize {
+        self.print_queue_size.0
+    }
+
+    pub fn work_queue_size(&self) -> usize {
+        self.work_queue_size.0
+    }
+
+    pub fn num_workers(&self) -> usize {
+        self.num_workers.0
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(transparent)]
+pub struct PrintQueueSize(usize);
+
+impl Default for PrintQueueSize {
+    fn default() -> Self {
+        PrintQueueSize(100)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(transparent)]
+pub struct WorkQueueSize(usize);
+
+impl Default for WorkQueueSize {
+    fn default() -> Self {
+        WorkQueueSize(100)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(transparent)]
+pub struct NumWorkers(usize);
+
+impl Default for NumWorkers {
+    fn default() -> Self {
+        let num = Handle::current().metrics().num_workers() - 1;
+        NumWorkers(num)
+    }
+}

--- a/omnibor-cli/src/error.rs
+++ b/omnibor-cli/src/error.rs
@@ -2,6 +2,7 @@
 
 use async_channel::SendError;
 use omnibor::Error as OmniborError;
+use serde_json::Error as JsonError;
 use std::{io::Error as IoError, path::PathBuf, result::Result as StdResult};
 use tokio::task::JoinError;
 
@@ -70,6 +71,30 @@ pub enum Error {
 
     #[error("print channel closed")]
     PrintChannelClose,
+
+    #[error("did not find configuration file '{}'", path.display())]
+    ConfigNotFound {
+        path: PathBuf,
+        #[source]
+        source: IoError,
+    },
+
+    #[error("could not read default configuration file '{}'", path.display())]
+    ConfigDefaultCouldNotRead {
+        path: PathBuf,
+        #[source]
+        source: IoError,
+    },
+
+    #[error("could not read configuration file '{}'", path.display())]
+    ConfigCouldNotRead {
+        path: PathBuf,
+        #[source]
+        source: IoError,
+    },
+
+    #[error("can't read configuration file")]
+    CantReadConfig(#[source] JsonError),
 }
 
 pub type Result<T> = StdResult<T, Error>;

--- a/omnibor-cli/src/log.rs
+++ b/omnibor-cli/src/log.rs
@@ -1,0 +1,56 @@
+//! Functions for initializing logging.
+
+use clap_verbosity_flag::{InfoLevel, Verbosity};
+use tracing::Subscriber;
+use tracing_subscriber::{
+    filter::EnvFilter, layer::SubscriberExt as _, registry::LookupSpan,
+    util::SubscriberInitExt as _, Layer,
+};
+
+// The environment variable to use when configuring the log.
+const LOG_VAR: &str = "OMNIBOR_LOG";
+
+pub fn init_log(verbosity: Verbosity<InfoLevel>, console: bool) {
+    let level_filter = adapt_level_filter(verbosity.log_level_filter());
+    let filter = EnvFilter::from_env(LOG_VAR).add_directive(level_filter.into());
+    let fmt_layer = fmt_layer(filter);
+    let registry = tracing_subscriber::registry().with(fmt_layer);
+
+    if console {
+        let console_layer = console_subscriber::spawn();
+        registry.with(console_layer).init();
+    } else {
+        registry.init()
+    }
+}
+
+fn fmt_layer<S>(filter: EnvFilter) -> impl Layer<S>
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    tracing_subscriber::fmt::layer()
+        .event_format(
+            tracing_subscriber::fmt::format()
+                .with_level(true)
+                .without_time()
+                .with_target(false)
+                .with_thread_ids(false)
+                .with_thread_names(false)
+                .compact(),
+        )
+        .with_filter(filter)
+}
+
+/// Convert the clap LevelFilter to the tracing LevelFilter.
+fn adapt_level_filter(
+    clap_filter: clap_verbosity_flag::LevelFilter,
+) -> tracing_subscriber::filter::LevelFilter {
+    match clap_filter {
+        clap_verbosity_flag::LevelFilter::Off => tracing_subscriber::filter::LevelFilter::OFF,
+        clap_verbosity_flag::LevelFilter::Error => tracing_subscriber::filter::LevelFilter::ERROR,
+        clap_verbosity_flag::LevelFilter::Warn => tracing_subscriber::filter::LevelFilter::WARN,
+        clap_verbosity_flag::LevelFilter::Info => tracing_subscriber::filter::LevelFilter::INFO,
+        clap_verbosity_flag::LevelFilter::Debug => tracing_subscriber::filter::LevelFilter::DEBUG,
+        clap_verbosity_flag::LevelFilter::Trace => tracing_subscriber::filter::LevelFilter::TRACE,
+    }
+}

--- a/omnibor-cli/src/main.rs
+++ b/omnibor-cli/src/main.rs
@@ -1,27 +1,25 @@
+mod app;
 mod cli;
 mod cmd;
+mod config;
 mod error;
 mod fs;
+mod log;
 mod print;
 
 use crate::{
-    cli::{ArtifactCommand, Command, Config, DebugCommand, ManifestCommand},
+    app::App,
+    cli::{Args, ArtifactCommand, Command, DebugCommand, ManifestCommand},
     cmd::{artifact, debug, manifest},
+    config::Config,
     error::Result,
+    log::init_log,
     print::{error::ErrorMsg, PrintSender, Printer, PrinterCmd},
 };
 use clap::Parser as _;
-use clap_verbosity_flag::{InfoLevel, Verbosity};
 use std::process::ExitCode;
 use tokio::runtime::Runtime;
-use tracing::{trace, Subscriber};
-use tracing_subscriber::{
-    filter::EnvFilter, layer::SubscriberExt as _, registry::LookupSpan,
-    util::SubscriberInitExt as _, Layer,
-};
-
-// The environment variable to use when configuring the log.
-const LOG_VAR: &str = "OMNIBOR_LOG";
+use tracing::{error, trace};
 
 fn main() -> ExitCode {
     let runtime = Runtime::new().expect("runtime construction succeeds");
@@ -29,20 +27,30 @@ fn main() -> ExitCode {
 }
 
 async fn run() -> ExitCode {
-    let config = Config::parse();
-    init_log(&config.verbose);
-    // TODO: Make this tunable.
-    let printer = Printer::launch(100);
-    trace!(config = ?config);
+    let args = Args::parse();
+    init_log(args.verbosity(), args.console());
 
-    match run_cmd(printer.tx(), &config).await {
+    let config = match Config::init(args.config()) {
+        Ok(config) => config,
+        Err(error) => {
+            error!("error: {}", error);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let app = App { args, config };
+    trace!(app = ?app);
+
+    let printer = Printer::launch(app.config.perf.print_queue_size());
+
+    match run_cmd(printer.tx(), &app).await {
         Ok(_) => {
             printer.join().await;
             ExitCode::SUCCESS
         }
         Err(e) => {
             printer
-                .send(PrinterCmd::msg(ErrorMsg::new(e), config.format()))
+                .send(PrinterCmd::msg(ErrorMsg::new(e), app.args.format()))
                 .await;
             printer.join().await;
             ExitCode::FAILURE
@@ -50,73 +58,20 @@ async fn run() -> ExitCode {
     }
 }
 
-#[cfg(feature = "console")]
-/// Initialize the logging / tracing.
-fn init_log(verbosity: &Verbosity<InfoLevel>) {
-    let level_filter = adapt_level_filter(verbosity.log_level_filter());
-    let filter = EnvFilter::from_env(LOG_VAR).add_directive(level_filter.into());
-    let fmt_layer = fmt_layer(filter);
-    let console_layer = console_subscriber::spawn();
-    tracing_subscriber::registry()
-        .with(fmt_layer)
-        .with(console_layer)
-        .init();
-}
-
-#[cfg(not(feature = "console"))]
-/// Initialize the logging / tracing.
-fn init_log(verbosity: &Verbosity<InfoLevel>) {
-    let level_filter = adapt_level_filter(verbosity.log_level_filter());
-    let filter = EnvFilter::from_env(LOG_VAR).add_directive(level_filter.into());
-    let fmt_layer = fmt_layer(filter);
-    tracing_subscriber::registry().with(fmt_layer).init();
-}
-
-fn fmt_layer<S>(filter: EnvFilter) -> impl Layer<S>
-where
-    S: Subscriber + for<'span> LookupSpan<'span>,
-{
-    tracing_subscriber::fmt::layer()
-        .event_format(
-            tracing_subscriber::fmt::format()
-                .with_level(true)
-                .without_time()
-                .with_target(false)
-                .with_thread_ids(false)
-                .with_thread_names(false)
-                .compact(),
-        )
-        .with_filter(filter)
-}
-
-/// Convert the clap LevelFilter to the tracing LevelFilter.
-fn adapt_level_filter(
-    clap_filter: clap_verbosity_flag::LevelFilter,
-) -> tracing_subscriber::filter::LevelFilter {
-    match clap_filter {
-        clap_verbosity_flag::LevelFilter::Off => tracing_subscriber::filter::LevelFilter::OFF,
-        clap_verbosity_flag::LevelFilter::Error => tracing_subscriber::filter::LevelFilter::ERROR,
-        clap_verbosity_flag::LevelFilter::Warn => tracing_subscriber::filter::LevelFilter::WARN,
-        clap_verbosity_flag::LevelFilter::Info => tracing_subscriber::filter::LevelFilter::INFO,
-        clap_verbosity_flag::LevelFilter::Debug => tracing_subscriber::filter::LevelFilter::DEBUG,
-        clap_verbosity_flag::LevelFilter::Trace => tracing_subscriber::filter::LevelFilter::TRACE,
-    }
-}
-
 /// Select and run the chosen command.
-async fn run_cmd(tx: &PrintSender, config: &Config) -> Result<()> {
-    match config.command() {
+async fn run_cmd(tx: &PrintSender, app: &App) -> Result<()> {
+    match app.args.command() {
         Command::Artifact(ref args) => match args.command() {
-            ArtifactCommand::Id(ref args) => artifact::id::run(tx, config, args).await?,
-            ArtifactCommand::Find(ref args) => artifact::find::run(tx, config, args).await?,
+            ArtifactCommand::Id(ref args) => artifact::id::run(tx, app, args).await?,
+            ArtifactCommand::Find(ref args) => artifact::find::run(tx, app, args).await?,
         },
         Command::Manifest(ref args) => match args.command() {
-            ManifestCommand::Add(ref args) => manifest::add::run(tx, config, args).await?,
-            ManifestCommand::Remove(ref args) => manifest::remove::run(tx, config, args).await?,
-            ManifestCommand::Create(ref args) => manifest::create::run(tx, config, args).await?,
+            ManifestCommand::Add(ref args) => manifest::add::run(tx, app, args).await?,
+            ManifestCommand::Remove(ref args) => manifest::remove::run(tx, app, args).await?,
+            ManifestCommand::Create(ref args) => manifest::create::run(tx, app, args).await?,
         },
         Command::Debug(ref args) => match args.command() {
-            DebugCommand::Config => debug::config::run(tx, config).await?,
+            DebugCommand::Config => debug::config::run(tx, app).await?,
         },
     }
 

--- a/omnibor-cli/tests/snapshots/test__artifact_no_args.snap
+++ b/omnibor-cli/tests/snapshots/test__artifact_no_args.snap
@@ -29,3 +29,5 @@ General Flags:
   -f, --format <FORMAT>  Output format [env: OMNIBOR_FORMAT=] [possible values: plain, json, short]
   -H, --hash <HASH>      Hash algorithm to use when parsing Artifact IDs [env: OMNIBOR_HASH=] [possible values: sha256]
   -d, --dir <DIR>        Directory to store manifests [env: OMNIBOR_DIR=]
+  -c, --config <CONFIG>  Path to a configuration file [env: OMNIBOR_CONFIG=]
+      --console          Turn on 'tokio-console' debug integration [env: OMNIBOR_CONSOLE=]

--- a/omnibor-cli/tests/snapshots/test__debug_no_args.snap
+++ b/omnibor-cli/tests/snapshots/test__debug_no_args.snap
@@ -28,3 +28,5 @@ General Flags:
   -f, --format <FORMAT>  Output format [env: OMNIBOR_FORMAT=] [possible values: plain, json, short]
   -H, --hash <HASH>      Hash algorithm to use when parsing Artifact IDs [env: OMNIBOR_HASH=] [possible values: sha256]
   -d, --dir <DIR>        Directory to store manifests [env: OMNIBOR_DIR=]
+  -c, --config <CONFIG>  Path to a configuration file [env: OMNIBOR_CONFIG=]
+      --console          Turn on 'tokio-console' debug integration [env: OMNIBOR_CONSOLE=]

--- a/omnibor-cli/tests/snapshots/test__manifest_no_args.snap
+++ b/omnibor-cli/tests/snapshots/test__manifest_no_args.snap
@@ -30,3 +30,5 @@ General Flags:
   -f, --format <FORMAT>  Output format [env: OMNIBOR_FORMAT=] [possible values: plain, json, short]
   -H, --hash <HASH>      Hash algorithm to use when parsing Artifact IDs [env: OMNIBOR_HASH=] [possible values: sha256]
   -d, --dir <DIR>        Directory to store manifests [env: OMNIBOR_DIR=]
+  -c, --config <CONFIG>  Path to a configuration file [env: OMNIBOR_CONFIG=]
+      --console          Turn on 'tokio-console' debug integration [env: OMNIBOR_CONSOLE=]

--- a/omnibor-cli/tests/snapshots/test__no_args.snap
+++ b/omnibor-cli/tests/snapshots/test__no_args.snap
@@ -29,3 +29,5 @@ General Flags:
   -f, --format <FORMAT>  Output format [env: OMNIBOR_FORMAT=] [possible values: plain, json, short]
   -H, --hash <HASH>      Hash algorithm to use when parsing Artifact IDs [env: OMNIBOR_HASH=] [possible values: sha256]
   -d, --dir <DIR>        Directory to store manifests [env: OMNIBOR_DIR=]
+  -c, --config <CONFIG>  Path to a configuration file [env: OMNIBOR_CONFIG=]
+      --console          Turn on 'tokio-console' debug integration [env: OMNIBOR_CONSOLE=]


### PR DESCRIPTION
This introduces an optional config file which permits the user to tune the operation of the CLI. For now this is just parameters related to Tokio runtime execution; there may be more options in the future.