### PR TITLE
feat: Change naming of manifest file.

### DIFF
--- a/omnibor-cli/src/cmd/manifest/create.rs
+++ b/omnibor-cli/src/cmd/manifest/create.rs
@@ -97,7 +97,5 @@ fn manifest_file_path(output: Option<&Path>, target_aid: ArtifactId<Sha256>) -> 
         },
     };
 
-    let file_name = format!("{}.manifest", target_aid.as_hex());
-
-    Ok(pathbuf![&dir, &file_name])
+    Ok(pathbuf![&dir, &target_aid.as_file_name()])
 }

--- a/omnibor/src/artifact_id.rs
+++ b/omnibor/src/artifact_id.rs
@@ -336,8 +336,11 @@ impl<H: SupportedHash> ArtifactId<H> {
     ///
     /// What that means for us is that the `:` separator character is
     /// replaced with `_`.
-    pub fn safe_name(&self) -> PathBuf {
-        self.gitoid.url().to_string().replace(':', "_").into()
+    pub fn as_file_name(&self) -> PathBuf {
+        let name = self.gitoid.url().to_string().replace(':', "_");
+        let mut path = PathBuf::from(name);
+        path.set_extension("manifest");
+        path
     }
 
     /// Get the underlying bytes of the [`ArtifactId`] hash.


### PR DESCRIPTION
This updates the naming to use `ArtifactId::as_file_name`.
