### PR TITLE
chore: Make Docs.rs show feature annotations.

### DIFF
--- a/omnibor/Cargo.toml
+++ b/omnibor/Cargo.toml
@@ -94,3 +94,11 @@ backend-openssl = ["dep:openssl"]
 [[bench]]
 name = "benchmark"
 harness = false
+
+[package.metadata.docs.rs]
+
+# Whether to pass `--all-features` to Cargo (default: false)
+all-features = true
+
+# Defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]

--- a/omnibor/src/hash_provider/boringssl.rs
+++ b/omnibor/src/hash_provider/boringssl.rs
@@ -10,6 +10,7 @@ use {
 };
 
 /// Use the BoringSSL hash implementation.
+#[cfg_attr(docsrs, doc(cfg(feature = "backend-boringssl")))]
 #[derive(Clone, Copy)]
 pub struct BoringSsl {
     #[doc(hidden)]

--- a/omnibor/src/hash_provider/openssl.rs
+++ b/omnibor/src/hash_provider/openssl.rs
@@ -10,6 +10,7 @@ use {
 };
 
 /// Use the OpenSSL hash implementation.
+#[cfg_attr(docsrs, doc(cfg(feature = "backend-openssl")))]
 #[derive(Clone, Copy)]
 pub struct OpenSsl {
     #[doc(hidden)]

--- a/omnibor/src/hash_provider/rustcrypto.rs
+++ b/omnibor/src/hash_provider/rustcrypto.rs
@@ -11,6 +11,7 @@ use {
 };
 
 /// Use the RustCrypto hash implementation.
+#[cfg_attr(docsrs, doc(cfg(feature = "backend-rustcrypto")))]
 #[derive(Clone, Copy)]
 pub struct RustCrypto {
     #[doc(hidden)]

--- a/omnibor/src/lib.rs
+++ b/omnibor/src/lib.rs
@@ -266,6 +266,7 @@
  */
 
 #![allow(clippy::module_inception)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 /*===============================================================================================
  * Compilation Protections


### PR DESCRIPTION
Some parts of our API rely on features being turned on, and it would be good to show that fact on Docs.rs.