### PR TITLE
chore: Removed unused dependencies.

### DIFF
--- a/omnibor/Cargo.toml
+++ b/omnibor/Cargo.toml
@@ -52,9 +52,7 @@ hex = "0.4.3"
 serde = { version = "1.0.197", features = ["derive"] }
 thiserror = "2.0.0"
 tokio = { version = "1.36.0", features = ["io-util", "fs"] }
-tracing = "0.1.40"
 url = "2.4.1"
-paste = "1.0.15"
 walkdir = { version = "2.5.0" }
 
 [dev-dependencies]

--- a/omnibor/src/storage/file_system_storage.rs
+++ b/omnibor/src/storage/file_system_storage.rs
@@ -20,7 +20,6 @@ use {
         path::{Path, PathBuf},
         str::FromStr,
     },
-    tracing::{debug, info},
     walkdir::{DirEntry, WalkDir},
 };
 
@@ -194,8 +193,6 @@ impl<H: HashAlgorithm, P: HashProvider<H>> Storage<H> for FileSystemStorage<H, P
             InputManifestError::CantWriteManifest(path.clone_as_boxstr(), Box::new(source))
         })?;
 
-        info!("wrote manifest '{}' to store", manifest_aid);
-
         Ok(manifest_aid)
     }
 
@@ -234,8 +231,6 @@ fn artifact_id_from_dir_entry<H: HashAlgorithm>(entry: &DirEntry) -> Option<Arti
         let front = meta.replace('_', ":");
         format!("{}:{}", front, hash)
     };
-
-    debug!(gitoid_url = %gitoid_url);
 
     ArtifactId::<H>::from_str(&gitoid_url).ok()
 }


### PR DESCRIPTION
Technically `tracing` had two use sites, but neither was particularly useful. I'm happy to put `tracing` back in sometime in the future when I can go through the crate and make sure we're being consistent about when and how we do logging.
