### PR TITLE
feat(cli)!: Make `manifest create` input files positional

### DIFF
--- a/omnibor-cli/src/cli.rs
+++ b/omnibor-cli/src/cli.rs
@@ -194,7 +194,7 @@ pub struct ManifestRemoveArgs {}
 #[command(arg_required_else_help = true)]
 pub struct ManifestCreateArgs {
     /// Inputs to record in the manifest.
-    #[arg(short = 'i', long = "input", help_heading = IMPORTANT)]
+    #[arg(help_heading = IMPORTANT)]
     pub inputs: Vec<IdentifiableArg>,
 
     /// The target the manifest is describing.


### PR DESCRIPTION
This amends the `manifest create` arguments, turning the list of input files from a flag (`-i` / `--input`) into a positional argument. Normally I'm wary of positional arguments because they're less backwards compatible [1], but in this case this argument should always be the primary one, and making it positional makes it easier to integrate with things like shell subcommands to produce a file list.

[1]: https://clig.dev/#arguments-and-flags

Closes #243