### PR TITLE
chore!: Update Ubuntu runners to 22.04.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -174,7 +174,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -224,7 +224,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -288,7 +288,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -27,3 +27,18 @@ install-updater = true
 github-attestations = true
 # Path that installers should place binaries in
 install-path = ["~/.local/bin", "~/.omnibor/bin"]
+
+# NOTE: MUST be synced manually with runners in `.github/workflows/hipcheck.yml`
+[dist.github-custom-runners]
+global = "ubuntu-22.04"
+# Ensure Apple Silicon macOS builds run natively rather than cross-compiling
+# from x86. Also makes sure our Apple Silicon macOS release builds match the
+# runner used for regular CI testing.
+aarch64-apple-darwin = "macos-14"
+# Update our Ubuntu release runs away from Ubuntu 20.04, which is now being
+# sunset by GitHub. They only track the last two LTS Ubuntu releases for free
+# runners, and with 24.04 out they're sunsetting 20.04. We're *just* moving to
+# 22.04, since releases compiled against 22.04's glibc should be forwards-
+# compatible with 24.04, but if we built on 24.04 the glibc *would not* be
+# backwards-compatible.
+x86_64-unknown-linux-gnu = "ubuntu-22.04"


### PR DESCRIPTION
GitHub has deprecated support for Ubuntu 20.04 on the free tier, so we need to upgrade to use 22.04.