### PR TITLE
chore!: Sync test runners w/ release runners.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-13, macos-14]
+        os: [ubuntu-22.04, windows-2019, macos-13, macos-14]
     name: "${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15


### PR DESCRIPTION
This amends the list of CI runners for test jobs to use Ubuntu 22.04, since GitHub has sunset 20.04. This also syncs the runners between test and release, with release runners managed by `dist`.